### PR TITLE
ci: update timeout for cypress

### DIFF
--- a/apps/app-e2e/cypress.json
+++ b/apps/app-e2e/cypress.json
@@ -8,5 +8,6 @@
   "video": true,
   "videosFolder": "../../dist/cypress/apps/app-e2e/videos",
   "screenshotsFolder": "../../dist/cypress/apps/app-e2e/screenshots",
-  "chromeWebSecurity": false
+  "chromeWebSecurity": false,
+  "defaultCommandTimeout": 8000
 }


### PR DESCRIPTION
Sometimes, DOM will take more time than expected to load which result in a failure of e2e tests. But after a job restart, tests pass !