### PR TITLE
ci: push images from pr

### DIFF
--- a/.github/workflows/cd-docker.yml
+++ b/.github/workflows/cd-docker.yml
@@ -42,7 +42,6 @@ jobs:
             type=sha
 
       - name: Login to DockerHub
-        if: github.event_name != 'pull_request'
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKER_HUB_USER }}
@@ -52,7 +51,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
-          push: ${{ github.event_name != 'pull_request' }}
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           file: ${{ matrix.dockerfile.file }}

--- a/.github/workflows/cd-docker.yml
+++ b/.github/workflows/cd-docker.yml
@@ -3,9 +3,9 @@ name: CD Docker
 on:
   push:
     branches:
-      - "main"
+      - 'main'
     tags:
-      - "v*.*.*"
+      - 'v*.*.*'
 
 jobs:
   docker:

--- a/.github/workflows/cd-docker.yml
+++ b/.github/workflows/cd-docker.yml
@@ -1,11 +1,11 @@
-name: cd docker
+name: CD Docker
 
 on:
   push:
     branches:
-      - 'main'
+      - "main"
     tags:
-      - 'v*.*.*'
+      - "v*.*.*"
 
 jobs:
   docker:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -146,7 +146,7 @@ jobs:
         uses: cypress-io/github-action@v4
         with:
           install-command: npx cypress install
-          start: "npx nx serve api"
+          start: 'npx nx serve api'
           command: npx nx e2e app-e2e
 
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -219,7 +219,7 @@ jobs:
             type=sha
 
       - name: Login to DockerHub
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'push'
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKER_HUB_USER }}
@@ -229,7 +229,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
-          push: ${{ github.event_name != 'pull_request' }}
+          push: ${{ github.event_name != 'push' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           file: ${{ matrix.dockerfile.file }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -146,7 +146,7 @@ jobs:
         uses: cypress-io/github-action@v4
         with:
           install-command: npx cypress install
-          start: 'npx nx serve api'
+          start: "npx nx serve api"
           command: npx nx e2e app-e2e
 
       - uses: actions/upload-artifact@v2
@@ -218,10 +218,18 @@ jobs:
             type=semver,pattern={{major}}
             type=sha
 
-      - name: Docker build
+      - name: Login to DockerHub
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_HUB_USER }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+
+      - name: Build and push
         uses: docker/build-push-action@v2
         with:
           context: .
+          push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           file: ${{ matrix.dockerfile.file }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -210,13 +210,7 @@ jobs:
             dockerhubaneo/${{ matrix.dockerfile.name }}
           # generate Docker tags based on the following events/attributes
           tags: |
-            type=schedule
-            type=ref,event=branch
             type=ref,event=pr
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
-            type=sha
 
       - name: Login to DockerHub
         if: github.event_name != 'push'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -146,7 +146,7 @@ jobs:
         uses: cypress-io/github-action@v4
         with:
           install-command: npx cypress install
-          start: 'npx nx serve api'
+          start: "npx nx serve api"
           command: npx nx e2e app-e2e
 
       - uses: actions/upload-artifact@v2
@@ -184,7 +184,7 @@ jobs:
       - name: Build all
         run: npx nx affected --target=build --parallel=3
 
-  build-docker-images:
+  build-push-docker-images:
     needs: build
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
The new pipeline allow us to build and push images because they won't be created and pushed if tests fails.

This will allow us to use pr image on dev environment