### PR TITLE
fix: clearing all filters now set each filter unactive

### DIFF
--- a/apps/app/src/app/results/feature/results-list/results-list.page.ts
+++ b/apps/app/src/app/results/feature/results-list/results-list.page.ts
@@ -304,6 +304,10 @@ export class ResultsListComponent implements OnInit {
    * Clear all filters currently applied to the datagrid
    */
   clearAllFilters(): void {
+    // Reset the filters so that they doesn't stay active
+    this._state.filters?.forEach((filter) => {
+      filter.reset();
+    })
     delete this._state.filters;
     this._subjectDatagrid.next(this._state);
   }

--- a/apps/app/src/app/results/feature/results-list/results-list.page.ts
+++ b/apps/app/src/app/results/feature/results-list/results-list.page.ts
@@ -307,7 +307,7 @@ export class ResultsListComponent implements OnInit {
     // Reset the filters so that they doesn't stay active
     this._state.filters?.forEach((filter) => {
       filter.reset();
-    })
+    });
     delete this._state.filters;
     this._subjectDatagrid.next(this._state);
   }

--- a/apps/app/src/app/shared/feature/filters/combobox-filter/combobox-filter.component.ts
+++ b/apps/app/src/app/shared/feature/filters/combobox-filter/combobox-filter.component.ts
@@ -51,6 +51,10 @@ export class ComboBoxFilterComponent
     this.changes.emit();
   }
 
+  reset(): void {
+    this.selectedValues = [];
+  }
+
   /**
    * Unused but required by the interface.
    */

--- a/apps/app/src/app/shared/feature/filters/date-filter/date-filter.component.ts
+++ b/apps/app/src/app/shared/feature/filters/date-filter/date-filter.component.ts
@@ -51,6 +51,11 @@ export class DateFilterComponent
     this.changes.emit();
   }
 
+  reset() {
+    this.beforeDate = null;
+    this.afterDate = null;
+  }
+
   /**
    * Check if the filter is active
    */

--- a/apps/app/src/app/shared/feature/filters/id-filter/id-filter.component.ts
+++ b/apps/app/src/app/shared/feature/filters/id-filter/id-filter.component.ts
@@ -67,6 +67,10 @@ export class IdFilterComponent
     this.changes.emit();
   }
 
+  reset() {
+    this.inputValue = null;
+  }
+
   isActive(): boolean {
     return !!this.inputValue && this.inputValue.length != 0;
   }

--- a/apps/app/src/app/shared/feature/filters/numeric-filter/numeric-filter.component.ts
+++ b/apps/app/src/app/shared/feature/filters/numeric-filter/numeric-filter.component.ts
@@ -35,6 +35,10 @@ export class NumericFilterComponent
     this.changes.emit();
   }
 
+  reset() {
+    this.selectedValue = null;
+  }
+
   isActive(): boolean {
     return !!this.selectedValue && this.selectedValue !== 0;
   }

--- a/apps/app/src/app/shared/feature/filters/select-filter/select-filter.component.ts
+++ b/apps/app/src/app/shared/feature/filters/select-filter/select-filter.component.ts
@@ -41,6 +41,10 @@ export class SelectFilterComponent
     this.changes.emit();
   }
 
+  reset(): void {
+    this.selectedValue = null;
+  }
+
   trackByLabel(_: number, item: { value: number; label: string }): string {
     return item.label;
   }

--- a/apps/app/src/app/tasks/feature/tasks-list/tasks-list.page.ts
+++ b/apps/app/src/app/tasks/feature/tasks-list/tasks-list.page.ts
@@ -455,6 +455,10 @@ export class TasksListComponent implements OnInit {
    * Clear all filters currently applied to the datagrid
    */
   clearAllFilters(): void {
+    // Reset the filters so that they doesn't stay active
+    this._state.filters?.forEach((filter) => {
+      filter.reset();
+    });
     delete this._state.filters;
     this._subjectDatagrid.next(this._state);
   }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue
fix #416 
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
Created `reset` function for each filter. These functions clear the filter without emitting any event.
Datagrid `clearAllFilters` functions call at first the `reset` function for every active filter, and then destroy the filters.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
