### PR TITLE
chore: fix group slug in renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,19 +15,19 @@
     },
     {
       "groupName": "npm angular packages",
-      "groupSlug": "npm",
+      "groupSlug": "npm-angular",
       "matchPackagePatterns": ["^@angular/"],
       "matchDatasources": ["npm"]
     },
     {
       "groupName": "npm clarity packages",
-      "groupSlug": "npm",
+      "groupSlug": "npm-clarity",
       "matchPackagePatterns": ["^@clr/", "^@cds/"],
       "matchDatasources": ["npm"]
     },
     {
       "groupName": "npm aneoconsultingfr packages",
-      "groupSlug": "npm",
+      "groupSlug": "npm-aneoconsultingfr",
       "matchPackagePatterns": ["^@aneoconsultingfr/"],
       "matchDatasources": ["npm"]
     },


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Group slug is used to group packages. In our case, we want to split package rules in different groups.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
