### PR TITLE
feat: dashboard statuses group redirect

### DIFF
--- a/src/app/dashboard/components/statuses-group-card.component.ts
+++ b/src/app/dashboard/components/statuses-group-card.component.ts
@@ -14,9 +14,9 @@ import { TasksStatusesGroup } from '../types';
 <mat-card>
   <mat-card-header *ngIf="!hideGroupHeaders">
     <mat-card-title>
-      <span [style]="'color:' + group.color">
+      <a routerLink="/tasks" [style]="'color:' + group.color + '; text-decoration: none'">
         {{ group.name }}
-      </span>
+      </a>
       <span>
         {{ sumStatusCount(group.statuses) }}
       </span>


### PR DESCRIPTION
#769 

Now redirecting on the Tasks page when clicking on a statuses group name on the dashboard 