### PR TITLE
feat: duration time from nano to ms

### DIFF
--- a/src/app/pipes/duration.pipe.ts
+++ b/src/app/pipes/duration.pipe.ts
@@ -10,7 +10,6 @@ export class DurationPipe  implements PipeTransform {
 
     const seconds = Number(value.seconds) || 0;
     const nano = value.nanos || 0;
-
     if (seconds === 0 && nano === 0) {
       return null;
     }
@@ -18,12 +17,13 @@ export class DurationPipe  implements PipeTransform {
     const hours = Math.floor(seconds / 3600);
     const minutes = Math.floor((seconds - (hours * 3600)) / 60);
     const secondsRemaining = seconds - (hours * 3600) - (minutes * 60);
+    const millis = Math.round((nano * Math.pow(10, -6))*1000)/1000;
 
     const hoursStr = hours > 0 ? `${hours}h ` : '';
     const minutesStr = minutes > 0 ? `${minutes}m ` : '';
     const secondsStr = secondsRemaining > 0 ? `${secondsRemaining}s ` : '';
-    const nanoStr = nano > 0 ? `${nano}ns` : '';
+    const millisStr = millis > 0 ? `${millis}ms` : '';
 
-    return `${hoursStr}${minutesStr}${secondsStr}${nanoStr}`.trim();
+    return `${hoursStr}${minutesStr}${secondsStr}${millisStr}`.trim();
   }
 }


### PR DESCRIPTION
In tasks table, durations have been switched to milliseconds. 
Fixes #767 