### PR TITLE
fix: replace finished status name by completed on dashboard & filters

### DIFF
--- a/src/app/components/view-tasks-by-status-dialog.component.spec.ts
+++ b/src/app/components/view-tasks-by-status-dialog.component.spec.ts
@@ -68,7 +68,7 @@ describe('ViewTasksByStatusDialogComponent', () => {
   });
 
   it('should retrieve a label by its corresponding status', () => {
-    expect(component.statusToLabel(TaskStatus.TASK_STATUS_COMPLETED)).toEqual('Finished');
+    expect(component.statusToLabel(TaskStatus.TASK_STATUS_COMPLETED)).toEqual('Completed');
   });
 
   describe('isUsedStatus', () => {

--- a/src/app/components/view-tasks-by-status.component.spec.ts
+++ b/src/app/components/view-tasks-by-status.component.spec.ts
@@ -61,7 +61,7 @@ describe('ViewTasksByStatusComponent', () => {
   });
 
   test('tooltip should get the label of a status ', () => {
-    expect(component.tooltip(TaskStatus.TASK_STATUS_COMPLETED)).toEqual('Finished');
+    expect(component.tooltip(TaskStatus.TASK_STATUS_COMPLETED)).toEqual('Completed');
   });
 
   test('trackByCount should return the status', () => {

--- a/src/app/dashboard/components/manage-groups-dialog.component.spec.ts
+++ b/src/app/dashboard/components/manage-groups-dialog.component.spec.ts
@@ -72,7 +72,7 @@ describe('ManageGroupsDialogComponent', () => {
   });
 
   it('should get statuses labels', () => {
-    expect(component.statusToLabel(TaskStatus.TASK_STATUS_COMPLETED)).toEqual('Finished');
+    expect(component.statusToLabel(TaskStatus.TASK_STATUS_COMPLETED)).toEqual('Completed');
   });
 
   it('should change array on drop', () => {

--- a/src/app/dashboard/components/statuses-group-card.component.spec.ts
+++ b/src/app/dashboard/components/statuses-group-card.component.spec.ts
@@ -25,7 +25,7 @@ describe('StatusesGroupCardComponent', () => {
   });
 
   it('should get labels', () => {
-    expect(component.statusToLabel(TaskStatus.TASK_STATUS_COMPLETED)).toEqual('Finished');
+    expect(component.statusToLabel(TaskStatus.TASK_STATUS_COMPLETED)).toEqual('Completed');
   });
 
   it('should update counter', () => {

--- a/src/app/dashboard/services/dashboard-index.service.spec.ts
+++ b/src/app/dashboard/services/dashboard-index.service.spec.ts
@@ -64,7 +64,7 @@ describe('DashboardIndexService', () => {
       { value: '1', name: 'Creating' },
       { value: '2', name: 'Submitted' },
       { value: '3', name: 'Dispatched' },
-      { value: '4', name: 'Finished' },
+      { value: '4', name: 'Completed' },
       { value: '5', name: 'Error' },
       { value: '6', name: 'Timeout' },
       { value: '7', name: 'Cancelling' },

--- a/src/app/tasks/services/tasks-filters.service.spec.ts
+++ b/src/app/tasks/services/tasks-filters.service.spec.ts
@@ -20,7 +20,7 @@ describe('TasksFilterService', () => {
       10: $localize`Processed`,
       7: $localize`Cancelling`,
       8: $localize`Cancelled`,
-      4: $localize`Finished`,
+      4: $localize`Completed`,
       5: $localize`Error`,
       6: $localize`Timeout`,
       11: $localize`Retried`,

--- a/src/app/tasks/services/tasks-statuses.service.ts
+++ b/src/app/tasks/services/tasks-statuses.service.ts
@@ -13,7 +13,7 @@ export class TasksStatusesService {
     [TaskStatus.TASK_STATUS_PROCESSED]: $localize`Processed`,
     [TaskStatus.TASK_STATUS_CANCELLING]: $localize`Cancelling`,
     [TaskStatus.TASK_STATUS_CANCELLED]: $localize`Cancelled`,
-    [TaskStatus.TASK_STATUS_COMPLETED]: $localize`Finished`,
+    [TaskStatus.TASK_STATUS_COMPLETED]: $localize`Completed`,
     [TaskStatus.TASK_STATUS_ERROR]: $localize`Error`,
     [TaskStatus.TASK_STATUS_TIMEOUT]: $localize`Timeout`,
     [TaskStatus.TASK_STATUS_RETRIED]: $localize`Retried`,


### PR DESCRIPTION
 - Replaced the "finished" status name by "completed" which was more relevant and less ambiguous in the dashboard statuses group `Finished` and also in the available statuses filter on the tasks page
 - Updated the corresponding tests