### PR TITLE
chore: update pod ttl display in task table

### DIFF
--- a/src/app/tasks/services/tasks-index.service.ts
+++ b/src/app/tasks/services/tasks-index.service.ts
@@ -78,6 +78,7 @@ export class TasksIndexService implements IndexServiceGenericInterface<TaskSumma
     {
       name: $localize`Pod TTL`,
       key: 'podTtl',
+      type: 'duration',
       sortable: true,
     },
     {


### PR DESCRIPTION
closes #960 