### PR TITLE
feat(sessions): support pause and resume

### DIFF
--- a/src/app/components/show-action-area.component.html
+++ b/src/app/components/show-action-area.component.html
@@ -4,7 +4,7 @@
     {{element.name}}
   </a>
 
-  <button mat-flat-button *ngIf="element.action$ && !element.link" (click)="element.action$.next()" [disabled]="element.disabled" [color]="element.color" >
+  <button mat-flat-button *ngIf="element.action$ && !element.link && element.show" (click)="element.action$.next()" [disabled]="element.disabled" [color]="element.color" >
     <mat-icon [fontIcon]="element.icon ?? ''" />
     {{element.name}}
   </button>

--- a/src/app/components/show-actions.component.ts
+++ b/src/app/components/show-actions.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule, NgFor, NgIf } from '@angular/common';
-import { Component, EventEmitter, Input, OnInit, Output, inject } from '@angular/core';
+import { Component, EventEmitter, Input, OnChanges, OnInit, Output, SimpleChanges, inject } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatToolbarModule } from '@angular/material/toolbar';
@@ -36,7 +36,7 @@ import { ShowActionAreaComponent } from './show-action-area.component';
     IconsService
   ]
 })
-export class ShowActionsComponent implements OnInit {
+export class ShowActionsComponent implements OnInit, OnChanges {
   @Input({ required: true }) actionsButton: ShowActionButton[];
   @Input({ required: true }) data: DataRaw = {} as DataRaw;
   @Input() id: string | null = null;
@@ -48,8 +48,15 @@ export class ShowActionsComponent implements OnInit {
   _iconsService = inject(IconsService);
 
   ngOnInit(): void {
-    this.leftActions = this.actionsButton.filter(action => action.area !== 'right');
-    this.rightActions = this.actionsButton.filter(action => action.area === 'right');
+    this.#splitActions()
+  }
+
+  /** Observe actions button to split them. Actions button can change when another one is clicked. */
+  ngOnChanges(changes: SimpleChanges): void {
+    if( 'actionsButton' in changes ) {
+    this.#splitActions()
+    }
+
   }
 
   onRefreshClick() {
@@ -58,5 +65,10 @@ export class ShowActionsComponent implements OnInit {
 
   getRefreshIcon() {
     return this._iconsService.getIcon('refresh');
+  }
+
+  #splitActions(): void {
+     this.leftActions = this.actionsButton.filter(action => action.area !== 'right');
+      this.rightActions = this.actionsButton.filter(action => action.area === 'right');
   }
 }

--- a/src/app/components/show-actions.component.ts
+++ b/src/app/components/show-actions.component.ts
@@ -48,13 +48,13 @@ export class ShowActionsComponent implements OnInit, OnChanges {
   _iconsService = inject(IconsService);
 
   ngOnInit(): void {
-    this.#splitActions()
+    this.#splitActions();
   }
 
   /** Observe actions button to split them. Actions button can change when another one is clicked. */
   ngOnChanges(changes: SimpleChanges): void {
     if( 'actionsButton' in changes ) {
-    this.#splitActions()
+      this.#splitActions();
     }
 
   }
@@ -68,7 +68,7 @@ export class ShowActionsComponent implements OnInit, OnChanges {
   }
 
   #splitActions(): void {
-     this.leftActions = this.actionsButton.filter(action => action.area !== 'right');
-      this.rightActions = this.actionsButton.filter(action => action.area === 'right');
+    this.leftActions = this.actionsButton.filter(action => action.area !== 'right');
+    this.rightActions = this.actionsButton.filter(action => action.area === 'right');
   }
 }

--- a/src/app/services/icons.service.ts
+++ b/src/app/services/icons.service.ts
@@ -37,6 +37,8 @@ export class IconsService {
     'storage': 'storage',
     'download': 'file_download',
     'upload': 'file_upload',
+    'pause': 'pause',
+    'play': 'play_arrow',
     'cancel': 'cancel',
     'copy': 'content_copy',
     'hub': 'hub',

--- a/src/app/sessions/components/table.component.ts
+++ b/src/app/sessions/components/table.component.ts
@@ -158,30 +158,31 @@ export class ApplicationsTableComponent implements OnInit, AfterViewInit {
       label: 'Pause session',
       icon: this.getIcon('pause'),
       action$: this.pauseSession$,
-      condition: (element: SessionData) => element.raw.status !== SessionStatus.SESSION_STATUS_PAUSED && element.raw.status !== SessionStatus.SESSION_STATUS_CANCELLED && element.raw.status !== SessionStatus.SESSION_STATUS_CLOSED
+      condition: (element: SessionData) => this._sessionsStatusesService.canPause(element.raw.status)
     },
     {
       label: 'Resume session',
       icon: this.getIcon('play'),
       action$: this.resumeSession$,
-      condition: (element: SessionData) => element.raw.status === SessionStatus.SESSION_STATUS_PAUSED
+      condition: (element: SessionData) => this._sessionsStatusesService.canResume(element.raw.status)
     },
     {
       label: 'Cancel session',
       icon: this.getIcon('cancel'),
       action$: this.cancelSession$,
-      condition: (element: SessionData) => element.raw.status === SessionStatus.SESSION_STATUS_RUNNING || element.raw.status === SessionStatus.SESSION_STATUS_PAUSED
+      condition: (element: SessionData) => this._sessionsStatusesService.canCancel(element.raw.status)
     },
     {
       label: 'Close session',
       icon: this.getIcon('close'),
       action$: this.closeSession$,
-      condition: (element: SessionData) => element.raw.status === SessionStatus.SESSION_STATUS_RUNNING || element.raw.status === SessionStatus.SESSION_STATUS_PAUSED
+      condition: (element: SessionData) => this._sessionsStatusesService.canClose(element.raw.status)
     },
     {
       label: 'Delete session',
       icon: this.getIcon('delete'),
       action$: this.deleteSession$,
+      condition: (element: SessionData) => this._sessionsStatusesService.canDelete(element.raw.status)
     }
   ];
 

--- a/src/app/sessions/components/table.component.ts
+++ b/src/app/sessions/components/table.component.ts
@@ -1,4 +1,4 @@
-import { FilterStringOperator, ResultRawEnumField, SessionRawEnumField, SessionStatus, TaskOptionEnumField, TaskSummaryEnumField } from '@aneoconsultingfr/armonik.api.angular';
+import { FilterStringOperator, ResultRawEnumField, SessionRawEnumField, TaskOptionEnumField, TaskSummaryEnumField } from '@aneoconsultingfr/armonik.api.angular';
 import { Clipboard} from '@angular/cdk/clipboard';
 import { CdkDragDrop, DragDropModule, moveItemInArray } from '@angular/cdk/drag-drop';
 import { DatePipe, NgFor, NgIf } from '@angular/common';

--- a/src/app/sessions/index.component.html
+++ b/src/app/sessions/index.component.html
@@ -2,7 +2,7 @@
     <mat-icon matListItemIcon aria-hidden="true" [fontIcon]="getPageIcon('sessions')"></mat-icon>
     <span i18n="Page title"> Sessions </span>
   </app-page-header>
-  
+
   <mat-toolbar>
     <mat-toolbar-row>
       <app-table-actions-toolbar
@@ -30,12 +30,12 @@
         </ng-container>
       </app-table-actions-toolbar>
     </mat-toolbar-row>
-  
+
     <mat-toolbar-row class="filters">
       <app-filters-toolbar [filters]="filters" [customColumns]="customColumns" (filtersChange)="onFiltersChange($event)"></app-filters-toolbar>
     </mat-toolbar-row>
   </mat-toolbar>
-  
+
   <app-sessions-table
     [data$]="data$"
     [filters]="filters"
@@ -44,6 +44,8 @@
     [options]="options"
     [total]="total"
     (optionsChange)="onOptionsChange()"
+    (pauseSession)="onPause($event)"
+    (resumeSession)="onResume($event)"
     (cancelSession)="onCancel($event)"
     (closeSession)="onClose($event)"
     (deleteSession)="onDelete($event)"

--- a/src/app/sessions/index.component.ts
+++ b/src/app/sessions/index.component.ts
@@ -379,31 +379,47 @@ export class IndexComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   onPause(sessionId: string) {
-    this._sessionsGrpcService.pause$(sessionId).subscribe(
-      () => this.refresh.next(),
-    );
+    this._sessionsGrpcService.pause$(sessionId)
+      .subscribe(
+        {
+          error: () => this.#notificationService.error('Unable to pause session'),
+          complete: () => this.refresh.next()
+        }
+      );
   }
 
   onResume(sessionId: string) {
     this._sessionsGrpcService.resume$(sessionId).subscribe(
-      () => this.refresh.next(),
+      {
+        error: () => this.#notificationService.error('Unable to resume session'),
+        complete: () => this.refresh.next()
+      }
     );
   }
 
   onCancel(sessionId: string) {
     this._sessionsGrpcService.cancel$(sessionId).subscribe(
-      () => this.refresh.next(),
+      {
+        error: () => this.#notificationService.error('Unable to cancel session'),
+        complete: () => this.refresh.next()
+      }
     );
   }
 
   onClose(sessionId: string) {
     this._sessionsGrpcService.close$(sessionId).subscribe(
-      () => this.refresh.next(),
+      {
+        error: () => this.#notificationService.error('Unable to close session'),
+        complete: () => this.refresh.next()
+      }
     );
   }
   onDelete(sessionId: string) {
     this._sessionsGrpcService.delete$(sessionId).subscribe(
-      () => this.refresh.next(),
+      {
+        error: () => this.#notificationService.error('Unable to delete session'),
+        complete: () => this.refresh.next()
+      }
     );
   }
 

--- a/src/app/sessions/index.component.ts
+++ b/src/app/sessions/index.component.ts
@@ -275,7 +275,7 @@ export class IndexComponent implements OnInit, AfterViewInit, OnDestroy {
         this.isLoading = false;
       }
     });
-    
+
     this.nextDuration$.pipe(
       map(sessionId => this._sessionsGrpcService.getTaskData$(sessionId, 'createdAt', 'asc')),
       mergeAll(),
@@ -368,7 +368,7 @@ export class IndexComponent implements OnInit, AfterViewInit, OnDestroy {
     this.options.pageIndex = 0;
     this.refresh.next();
   }
-  
+
   onLockColumnsChange() {
     this.lockColumns = !this.lockColumns;
     this._sessionsIndexService.saveLockColumns(this.lockColumns);
@@ -376,6 +376,18 @@ export class IndexComponent implements OnInit, AfterViewInit, OnDestroy {
 
   autoRefreshTooltip() {
     return this._autoRefreshService.autoRefreshTooltip(this.intervalValue);
+  }
+
+  onPause(sessionId: string) {
+    this._sessionsGrpcService.pause$(sessionId).subscribe(
+      () => this.refresh.next(),
+    );
+  }
+
+  onResume(sessionId: string) {
+    this._sessionsGrpcService.resume$(sessionId).subscribe(
+      () => this.refresh.next(),
+    );
   }
 
   onCancel(sessionId: string) {

--- a/src/app/sessions/services/sessions-grpc.service.ts
+++ b/src/app/sessions/services/sessions-grpc.service.ts
@@ -1,4 +1,4 @@
-import { CancelSessionRequest, CancelSessionResponse, CloseSessionRequest, CloseSessionResponse, DeleteSessionRequest, DeleteSessionResponse, FilterStringOperator, GetSessionRequest, GetSessionResponse, ListSessionsRequest, ListSessionsResponse, SessionFilterField, SessionRawEnumField, SessionTaskOptionEnumField, SessionsClient, TaskSummaryEnumField } from '@aneoconsultingfr/armonik.api.angular';
+import { CancelSessionRequest, CancelSessionResponse, CloseSessionRequest, CloseSessionResponse, DeleteSessionRequest, DeleteSessionResponse, FilterStringOperator, GetSessionRequest, GetSessionResponse, ListSessionsRequest, ListSessionsResponse, PauseSessionRequest, PauseSessionResponse, ResumeSessionRequest, ResumeSessionResponse, SessionFilterField, SessionRawEnumField, SessionTaskOptionEnumField, SessionsClient, TaskSummaryEnumField } from '@aneoconsultingfr/armonik.api.angular';
 import { Injectable, inject } from '@angular/core';
 import { SortDirection } from '@angular/material/sort';
 import { Observable, map } from 'rxjs';
@@ -66,6 +66,22 @@ export class SessionsGrpcService implements GrpcListInterface<SessionsClient, Se
     });
 
     return this.grpcClient.cancelSession(cancelSessionRequest);
+  }
+
+  pause$(sessionId: string): Observable<PauseSessionResponse> {
+    const pauseSessionRequest = new PauseSessionRequest({
+      sessionId
+    });
+
+    return this.grpcClient.pauseSession(pauseSessionRequest);
+  }
+
+  resume$(sessionId: string): Observable<ResumeSessionResponse> {
+    const resumeSessionRequest = new ResumeSessionRequest({
+      sessionId
+    });
+
+    return this.grpcClient.resumeSession(resumeSessionRequest);
   }
 
   close$(sessionId: string): Observable<CloseSessionResponse> {

--- a/src/app/sessions/services/sessions-statuses.service.ts
+++ b/src/app/sessions/services/sessions-statuses.service.ts
@@ -31,7 +31,7 @@ export class SessionsStatusesService implements StatusesServiceI<SessionStatus> 
   }
 
   canClose(status: SessionStatus): boolean {
-    return status === SessionStatus.SESSION_STATUS_RUNNING  || status === SessionStatus.SESSION_STATUS_PAUSED;
+    return status === SessionStatus.SESSION_STATUS_RUNNING || status === SessionStatus.SESSION_STATUS_PAUSED;
   }
 
   canDelete(status: SessionStatus): boolean {

--- a/src/app/sessions/services/sessions-statuses.service.ts
+++ b/src/app/sessions/services/sessions-statuses.service.ts
@@ -18,11 +18,23 @@ export class SessionsStatusesService implements StatusesServiceI<SessionStatus> 
     return this.statuses[status];
   }
 
-  canCancel(status: SessionStatus) {
-    return status !== SessionStatus.SESSION_STATUS_RUNNING;
+  canCancel(status: SessionStatus): boolean {
+    return status === SessionStatus.SESSION_STATUS_RUNNING  || status === SessionStatus.SESSION_STATUS_PAUSED;
   }
 
-  canClose(status: SessionStatus) {
-    return status === SessionStatus.SESSION_STATUS_RUNNING;
+  canPause(status: SessionStatus): boolean {
+    return status !== SessionStatus.SESSION_STATUS_PAUSED && status !== SessionStatus.SESSION_STATUS_CANCELLED && status !== SessionStatus.SESSION_STATUS_CLOSED;
+  }
+
+  canResume(status: SessionStatus): boolean {
+    return status === SessionStatus.SESSION_STATUS_PAUSED;
+  }
+
+  canClose(status: SessionStatus): boolean {
+    return status === SessionStatus.SESSION_STATUS_RUNNING  || status === SessionStatus.SESSION_STATUS_PAUSED;
+  }
+
+  canDelete(status: SessionStatus): boolean {
+    return status !== SessionStatus.SESSION_STATUS_DELETED;
   }
 }

--- a/src/app/sessions/show.component.ts
+++ b/src/app/sessions/show.component.ts
@@ -74,7 +74,6 @@ export class ShowComponent extends AppShowComponent<SessionRaw, SessionsGrpcServ
   protected override _grpcService = inject(SessionsGrpcService);
   private _filtersService = inject(FiltersService);
   private router = inject(Router);
-  #cdf = inject(ChangeDetectorRef);
 
   actionButtons: ShowActionButton[] = [];
 
@@ -267,64 +266,64 @@ export class ShowComponent extends AppShowComponent<SessionRaw, SessionsGrpcServ
 
   assignActions(): ShowActionButton[] {
     return [
-    {
-      id: 'tasks',
-      name: $localize`See tasks`,
-      icon: this.getPageIcon('tasks'),
-      link: '/tasks',
-      queryParams: {},
-    },
-    {
-      id: 'results',
-      name: $localize`See results`,
-      icon: this.getPageIcon('results'),
-      link: '/results',
-      queryParams: {},
-    },
-    {
-      id: 'partitions',
-      name: $localize`See partitions`,
-      icon: this.getPageIcon('partitions'),
-      link: '/partitions',
-      queryParams: {},
-    },
-    {
-      id: 'pause',
-      name: $localize`Pause Session`,
-      icon: this.getIcon('pause'),
-      action$: this.pause$,
-      show: this.canPause(),
-      color: 'accent',
-      area: 'right'
-    },
-    {
-      id: 'resume',
-      name: $localize`Resume Session`,
-      icon: this.getIcon('play'),
-      action$: this.resume$,
-      show: this.canResume(),
-      color: 'accent',
-      area: 'right'
-    },
-    {
-      id: 'cancel',
-      name: $localize`Cancel Session`,
-      icon: this.getIcon('cancel'),
-      action$: this.cancel$,
-      show: this.canCancel(),
-      color: 'accent',
-      area: 'right'
-    },
-    // TODO: Add missing close button in another PR.
-    {
-      id: 'delete',
-      name: $localize`Delete Session`,
-      icon: this.getIcon('delete'),
-      show: this.canDelete(),
-      action$: this.delete$,
-      color: 'accent',
-      area: 'right'
-    }
-  ];
-}
+      {
+        id: 'tasks',
+        name: $localize`See tasks`,
+        icon: this.getPageIcon('tasks'),
+        link: '/tasks',
+        queryParams: {},
+      },
+      {
+        id: 'results',
+        name: $localize`See results`,
+        icon: this.getPageIcon('results'),
+        link: '/results',
+        queryParams: {},
+      },
+      {
+        id: 'partitions',
+        name: $localize`See partitions`,
+        icon: this.getPageIcon('partitions'),
+        link: '/partitions',
+        queryParams: {},
+      },
+      {
+        id: 'pause',
+        name: $localize`Pause Session`,
+        icon: this.getIcon('pause'),
+        action$: this.pause$,
+        show: this.canPause(),
+        color: 'accent',
+        area: 'right'
+      },
+      {
+        id: 'resume',
+        name: $localize`Resume Session`,
+        icon: this.getIcon('play'),
+        action$: this.resume$,
+        show: this.canResume(),
+        color: 'accent',
+        area: 'right'
+      },
+      {
+        id: 'cancel',
+        name: $localize`Cancel Session`,
+        icon: this.getIcon('cancel'),
+        action$: this.cancel$,
+        show: this.canCancel(),
+        color: 'accent',
+        area: 'right'
+      },
+      // TODO: Add missing close button in another PR.
+      {
+        id: 'delete',
+        name: $localize`Delete Session`,
+        icon: this.getIcon('delete'),
+        show: this.canDelete(),
+        action$: this.delete$,
+        color: 'accent',
+        area: 'right'
+      }
+    ];
+  }
 }

--- a/src/app/sessions/show.component.ts
+++ b/src/app/sessions/show.component.ts
@@ -169,6 +169,8 @@ export class ShowComponent extends AppShowComponent<SessionRaw, SessionsGrpcServ
         this._filtersService.createFilterPartitionQueryParams(this.actionButtons, this.data.partitionIds);
         this._filtersService.createFilterQueryParams(this.actionButtons, 'results', this.resultsKey, this.data.sessionId);
         this._filtersService.createFilterQueryParams(this.actionButtons, 'tasks', this.tasksKey, this.data.sessionId);
+        this.canPause$.next(!this._sessionsStatusesService.canPause(this.data.status));
+        this.canResume$.next(!this._sessionsStatusesService.canResume(this.data.status));
         this.canCancel$.next(!this._sessionsStatusesService.canCancel(this.data.status));
         this.canClose$.next(!this._sessionsStatusesService.canClose(this.data.status));
         this.data$.next(data);

--- a/src/app/sessions/show.component.ts
+++ b/src/app/sessions/show.component.ts
@@ -1,5 +1,5 @@
 import { FilterStringOperator, ResultRawEnumField, SessionStatus, TaskSummaryEnumField } from '@aneoconsultingfr/armonik.api.angular';
-import { AfterViewInit, ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit, inject } from '@angular/core';
+import { AfterViewInit, Component, OnInit, inject } from '@angular/core';
 import { MatIconModule } from '@angular/material/icon';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { Router } from '@angular/router';

--- a/src/app/types/components/show.ts
+++ b/src/app/types/components/show.ts
@@ -12,6 +12,8 @@ export type ShowActionButton = {
   name: string;
   icon?: string;
   disabled?: boolean;
+  // TODO: Remove `disabled` in favor of `show` in another PR to avoid too many items in the interface. This behavior is similar in the table.
+  show?: boolean;
   link?: string;
   color?: 'accent' | 'primary';
   queryParams?: { [x: string]: string; };
@@ -42,7 +44,7 @@ export abstract class AppShowComponent<T extends object, E extends GrpcService> 
   sharableURL: string = '';
   refresh = new Subject<void>();
   data: T | null;
-  
+
   private _iconsService = inject(IconsService);
   protected _grpcService: E;
   private _shareURLService = inject(ShareUrlService);


### PR DESCRIPTION
fix #981 

Hey, 

This PR add the ability to pause and resume a session from the table and the show page.

I also refactor the bouncer for the session to have a single source of truth for capabilities between the table and the show page.

