### PR TITLE
chore: updated navigation types

### DIFF
--- a/src/app/applications/components/table.component.spec.ts
+++ b/src/app/applications/components/table.component.spec.ts
@@ -367,7 +367,7 @@ describe('TasksTableComponent', () => {
   });
 
   it('should get page icon', () => {
-    expect(component.getPageIcon('applications')).toEqual('apps');
+    expect(component.getIcon('applications')).toEqual('apps');
   });
 
   describe('actions', () => {

--- a/src/app/applications/components/table.component.ts
+++ b/src/app/applications/components/table.component.ts
@@ -7,7 +7,6 @@ import { TaskSummaryFilters } from '@app/tasks/types';
 import { AbstractTaskByStatusTableComponent } from '@app/types/components/table';
 import { ApplicationData } from '@app/types/data';
 import { Filter } from '@app/types/filters';
-import { Page } from '@app/types/pages';
 import { ActionTable } from '@app/types/table';
 import { TableComponent } from '@components/table/table.component';
 import { FiltersService } from '@services/filters.service';
@@ -50,7 +49,7 @@ export class ApplicationsTableComponent extends AbstractTaskByStatusTableCompone
   actions: ActionTable<ApplicationData>[] = [
     {
       label: $localize`See session`,
-      icon: this.getPageIcon('sessions'),
+      icon: this.getIcon('sessions'),
       action$: this.seeSessions$
     },
   ];
@@ -76,8 +75,8 @@ export class ApplicationsTableComponent extends AbstractTaskByStatusTableCompone
     };
   }
 
-  getPageIcon(name: Page): string {
-    return this.iconsService.getPageIcon(name);
+  getIcon(name: string): string {
+    return this.iconsService.getIcon(name);
   }
 
   createViewSessionsQueryParams(name: string, version: string) {

--- a/src/app/applications/index.component.html
+++ b/src/app/applications/index.component.html
@@ -1,5 +1,5 @@
 <app-page-header [sharableURL]="sharableURL">
-  <mat-icon matListItemIcon aria-hidden="true" [fontIcon]="getPageIcon('applications')"></mat-icon>
+  <mat-icon matListItemIcon aria-hidden="true" [fontIcon]="getIcon('applications')"></mat-icon>
   <span matListItemTitle i18n="Page title"> Applications </span>
 </app-page-header>
 

--- a/src/app/applications/index.component.spec.ts
+++ b/src/app/applications/index.component.spec.ts
@@ -180,7 +180,7 @@ describe('Application component', () => {
   });
 
   it('should get page icon', () => {
-    expect(component.getPageIcon('applications')).toEqual('apps');
+    expect(component.getIcon('applications')).toEqual('apps');
   });
 
   it('should refresh', () => {

--- a/src/app/components/table-index-actions-toolbar.component.html
+++ b/src/app/components/table-index-actions-toolbar.component.html
@@ -16,7 +16,7 @@
 <ng-content extra-buttons-right select="[extra-buttons-right]"></ng-content>
 <ng-container extra-menu-items>
   <button mat-menu-item (click)="onAddToDashboard()">
-    <mat-icon [fontIcon]="getPageIcon('dashboard')"/>
+    <mat-icon [fontIcon]="getIcon('dashboard')"/>
     <span i18n>Add to Dashboard</span>
   </button>
   <ng-content select="[extra-menu-items]"></ng-content>

--- a/src/app/components/table-index-actions-toolbar.component.spec.ts
+++ b/src/app/components/table-index-actions-toolbar.component.spec.ts
@@ -40,7 +40,7 @@ describe('TableDashboardActionsToolbarComponent', () => {
   });
 
   it('should get icon', () => {
-    expect(component.getPageIcon('sessions')).toEqual('workspaces');
+    expect(component.getIcon('sessions')).toEqual('workspaces');
   });
 
   it('should emit refresh', () => {

--- a/src/app/components/table-index-actions-toolbar.component.ts
+++ b/src/app/components/table-index-actions-toolbar.component.ts
@@ -2,7 +2,6 @@ import { Component, EventEmitter, Input, Output, inject } from '@angular/core';
 import { MatIconModule } from '@angular/material/icon';
 import { MatMenuModule } from '@angular/material/menu';
 import { ColumnKey, RawColumnKey } from '@app/types/data';
-import { Page } from '@app/types/pages';
 import { IconsService } from '@services/icons.service';
 import { TableActionsToolbarComponent } from './table-actions-toolbar.component';
 
@@ -35,8 +34,8 @@ export class TableIndexActionsToolbarComponent<T extends object, O extends objec
   @Output() lockColumnsChange = new EventEmitter<void>();
   @Output() addToDashboard = new EventEmitter<void>();
 
-  getPageIcon(string: Page): string {
-    return this.iconsService.getPageIcon(string);
+  getIcon(value: string): string {
+    return this.iconsService.getIcon(value);
   }
 
   onRefresh(): void {

--- a/src/app/dashboard/index.component.html
+++ b/src/app/dashboard/index.component.html
@@ -1,5 +1,5 @@
 <app-page-header [sharableURL]="sharableURL">
-    <mat-icon matListItemIcon aria-hidden="true" [fontIcon]="getPageIcon('dashboard')"></mat-icon>
+    <mat-icon matListItemIcon aria-hidden="true" [fontIcon]="getIcon('dashboard')"></mat-icon>
     <span i18n="Page title"> Dashboard </span>
   </app-page-header>
   

--- a/src/app/dashboard/index.component.spec.ts
+++ b/src/app/dashboard/index.component.spec.ts
@@ -93,10 +93,6 @@ describe('IndexComponent', () => {
     expect(component.getIcon('vertical-split')).toEqual('vertical_split');
   });
 
-  it('should get page icon', () => {
-    expect(component.getPageIcon('dashboard')).toEqual('dashboard');
-  });
-
   it('should open Fab', () => {
     component.openFab();
     expect(component.showFabActions).toBeTruthy();

--- a/src/app/dashboard/index.component.ts
+++ b/src/app/dashboard/index.component.ts
@@ -11,7 +11,6 @@ import { MatToolbarModule } from '@angular/material/toolbar';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { TasksStatusesService } from '@app/tasks/services/tasks-statuses.service';
 import { AddLineDialogData, AddLineDialogResult, ReorganizeLinesDialogData, ReorganizeLinesDialogResult, SplitLinesDialogData, SplitLinesDialogResult } from '@app/types/dialog';
-import { Page } from '@app/types/pages';
 import { ActionsToolbarGroupComponent } from '@components/actions-toolbar-group.component';
 import { ActionsToolbarComponent } from '@components/actions-toolbar.component';
 import { AutoRefreshButtonComponent } from '@components/auto-refresh-button.component';
@@ -158,22 +157,18 @@ export class IndexComponent implements OnInit {
     return this.#iconsService.getIcon(name);
   }
 
-  getPageIcon(name: Page): string {
-    return this.#iconsService.getPageIcon(name);
-  }
-
   getLineIcon(name: LineType): string {
     switch (name) {
     case 'Tasks':
-      return this.#iconsService.getPageIcon('tasks');
+      return this.#iconsService.getIcon('tasks');
     case 'Applications':
-      return this.#iconsService.getPageIcon('applications');
+      return this.#iconsService.getIcon('applications');
     case 'Partitions':
-      return this.#iconsService.getPageIcon('partitions');
+      return this.#iconsService.getIcon('partitions');
     case 'Results':
-      return this.#iconsService.getPageIcon('results');
+      return this.#iconsService.getIcon('results');
     case 'Sessions':
-      return this.#iconsService.getPageIcon('sessions');
+      return this.#iconsService.getIcon('sessions');
     case 'CountStatus':
       return this.#iconsService.getIcon('task-by-status');
     default:

--- a/src/app/healthcheck/index.component.html
+++ b/src/app/healthcheck/index.component.html
@@ -1,5 +1,5 @@
 <app-page-header>
-    <mat-icon matListItemIcon aria-hidden="true" [fontIcon]="getPageIcon()"></mat-icon>
+    <mat-icon matListItemIcon aria-hidden="true" [fontIcon]="getIcon()"></mat-icon>
     <span i18n="Page title" i18n>HealthChecks</span>
   </app-page-header>
   

--- a/src/app/healthcheck/index.component.spec.ts
+++ b/src/app/healthcheck/index.component.spec.ts
@@ -132,7 +132,7 @@ describe('IndexComponent', () => {
   });
 
   it('should get pageIcon', () => {
-    expect(component.getPageIcon()).toEqual('monitor_heart');
+    expect(component.getIcon()).toEqual('monitor_heart');
   });
 
   describe('getColor', () => {

--- a/src/app/healthcheck/index.component.ts
+++ b/src/app/healthcheck/index.component.ts
@@ -111,8 +111,8 @@ export class IndexComponent implements OnInit, AfterViewInit {
     }
   }
 
-  getPageIcon() {
-    return this.#iconsService.getPageIcon('healthcheck');
+  getIcon() {
+    return this.#iconsService.getIcon('healthcheck');
   }
 
   getColor(healthy: HealthStatusEnum) {

--- a/src/app/partitions/index.component.html
+++ b/src/app/partitions/index.component.html
@@ -1,5 +1,5 @@
 <app-page-header [sharableURL]="sharableURL">
-  <mat-icon matListItemIcon aria-hidden="true" [fontIcon]="getPageIcon('partitions')"></mat-icon>
+  <mat-icon matListItemIcon aria-hidden="true" [fontIcon]="getIcon('partitions')"></mat-icon>
   <span i18n="Page title">Partitions</span>
 </app-page-header>
 

--- a/src/app/partitions/index.component.spec.ts
+++ b/src/app/partitions/index.component.spec.ts
@@ -210,10 +210,6 @@ describe('Partitions Index Component', () => {
     });
   });
 
-  it('should get page icon', () => {
-    expect(component.getPageIcon('partitions')).toEqual('donut_small');
-  });
-
   it('should get icons', () => {
     expect(component.getIcon('refresh')).toEqual('refresh');
   });

--- a/src/app/partitions/show.component.spec.ts
+++ b/src/app/partitions/show.component.spec.ts
@@ -69,10 +69,6 @@ describe('ShowComponent', () => {
     });
   });
 
-  it('should get page icon', () => {
-    expect(component.getPageIcon('partitions')).toEqual('donut_small');
-  });
-
   it('should get icons', () => {
     expect(component.getIcon('refresh')).toEqual('refresh');
   });

--- a/src/app/partitions/show.component.ts
+++ b/src/app/partitions/show.component.ts
@@ -21,7 +21,7 @@ import { PartitionRaw } from './types';
   selector: 'app-partitions-show',
   template: `
 <app-show-page [id]="data?.id ?? ''" [data$]="data$" [sharableURL]="sharableURL" [actionsButton]="actionButtons" (refresh)="onRefresh()">
-  <mat-icon matListItemIcon aria-hidden="true" [fontIcon]="getPageIcon('partitions')"></mat-icon>
+  <mat-icon matListItemIcon aria-hidden="true" [fontIcon]="getIcon('partitions')"></mat-icon>
   <span i18n="Page title">Partition</span>
 </app-show-page>
   `,
@@ -54,7 +54,7 @@ export class ShowComponent extends AppShowComponent<PartitionRaw, PartitionsGrpc
     {
       id: 'sessions',
       name: $localize`See sessions`,
-      icon: this.getPageIcon('sessions'),
+      icon: this.getIcon('sessions'),
       link: '/sessions',
       queryParams: {},
       area: 'left'
@@ -62,7 +62,7 @@ export class ShowComponent extends AppShowComponent<PartitionRaw, PartitionsGrpc
     {
       id: 'tasks',
       name: $localize`See tasks`,
-      icon: this.getPageIcon('tasks'),
+      icon: this.getIcon('tasks'),
       link: '/tasks',
       queryParams: {},
       area: 'left'

--- a/src/app/profile/index.component.html
+++ b/src/app/profile/index.component.html
@@ -1,5 +1,5 @@
 <app-page-header [sharableURL]="sharableURL">
-    <mat-icon matListItemIcon aria-hidden="true" [fontIcon]="getPageIcon('profile')"></mat-icon>
+    <mat-icon matListItemIcon aria-hidden="true" [fontIcon]="getIcon('profile')"></mat-icon>
     <span>
       <span i18n="Page title"> Profile from </span>
       <span> {{ user.username }} </span>
@@ -37,7 +37,7 @@
         <ng-container *ngFor="let group of groupedPermissions()">
           <div class="permission">
             <h3>
-              <mat-icon matListItemIcon aria-hidden="true" [fontIcon]="getPageIcon(group.name)"></mat-icon>
+              <mat-icon matListItemIcon aria-hidden="true" [fontIcon]="getIcon(group.name)"></mat-icon>
               {{ group.name }}
             </h3>
             <ul>

--- a/src/app/profile/index.component.ts
+++ b/src/app/profile/index.component.ts
@@ -1,7 +1,6 @@
 import { NgFor, NgIf } from '@angular/common';
 import { Component, OnInit, inject } from '@angular/core';
 import { MatIconModule } from '@angular/material/icon';
-import { Page } from '@app/types/pages';
 import { PageHeaderComponent } from '@components/page-header.component';
 import { PageSectionHeaderComponent } from '@components/page-section-header.component';
 import { PageSectionComponent } from '@components/page-section.component';
@@ -9,7 +8,7 @@ import { IconsService } from '@services/icons.service';
 import { QueryParamsService } from '@services/query-params.service';
 import { ShareUrlService } from '@services/share-url.service';
 import { UserService } from '@services/user.service';
-import { PermissionGroup } from './types';
+import { Group, PermissionGroup, isGroup } from './types';
 
 @Component({
   selector: 'app-profile-index',
@@ -75,10 +74,6 @@ export class IndexComponent implements OnInit {
     return this.#iconsService.getIcon(name);
   }
 
-  getPageIcon(name: Page) {
-    return this.#iconsService.getPageIcon(name);
-  }
-
   groupedPermissions(): PermissionGroup[] {
     const permissions = this.#userService.user.permissions;
 
@@ -89,13 +84,15 @@ export class IndexComponent implements OnInit {
 
       const groupIndex = groups.findIndex(g => g.name === group.toLocaleLowerCase());
 
-      if (groupIndex === -1) {
-        groups.push({
-          name: group.toLowerCase() as Page,
-          permissions: [name],
-        });
-      } else {
-        groups[groupIndex].permissions.push(name);
+      if (isGroup(group.toLowerCase())) {
+        if (groupIndex === -1) {
+          groups.push({
+            name: group.toLowerCase() as Group,
+            permissions: [name],
+          });
+        } else {
+          groups[groupIndex].permissions.push(name);
+        }
       }
     }
 

--- a/src/app/profile/types.ts
+++ b/src/app/profile/types.ts
@@ -1,6 +1,11 @@
-import { Page } from '@app/types/pages';
+const ALL_GROUPS = ['applications', 'partitions', 'sessions', 'tasks', 'results', 'submitter', 'dashboard', 'profile', 'healthcheck'] as const;
+export type Group = typeof ALL_GROUPS[number];
 
 export type PermissionGroup = {
-  name: Page;
+  name: Group;
   permissions: string[];
 };
+
+export function isGroup(value: string): value is Group {
+  return ALL_GROUPS.includes(value as Group);
+}

--- a/src/app/results/index.component.html
+++ b/src/app/results/index.component.html
@@ -1,5 +1,5 @@
 <app-page-header [sharableURL]="sharableURL">
-  <mat-icon matListItemIcon aria-hidden="true" [fontIcon]="getPageIcon('results')"></mat-icon>
+  <mat-icon matListItemIcon aria-hidden="true" [fontIcon]="getIcon('results')"></mat-icon>
   <span i18n="Page title"> Results </span>
 </app-page-header>
 

--- a/src/app/results/index.component.spec.ts
+++ b/src/app/results/index.component.spec.ts
@@ -211,10 +211,6 @@ describe('Results Index Component', () => {
     });
   });
 
-  it('should get page icon', () => {
-    expect(component.getPageIcon('results')).toEqual('workspace_premium');
-  });
-
   it('should get icons', () => {
     expect(component.getIcon('refresh')).toEqual('refresh');
   });

--- a/src/app/results/show.component.spec.ts
+++ b/src/app/results/show.component.spec.ts
@@ -75,10 +75,6 @@ describe('ShowComponent', () => {
     });
   });
 
-  it('should get page icon', () => {
-    expect(component.getPageIcon('results')).toEqual('workspace_premium');
-  });
-
   it('should get icons', () => {
     expect(component.getIcon('refresh')).toEqual('refresh');
   });

--- a/src/app/results/show.component.ts
+++ b/src/app/results/show.component.ts
@@ -20,7 +20,7 @@ import { ResultsStatusesService } from './services/results-statuses.service';imp
   selector: 'app-result-show',
   template: `
 <app-show-page [id]="data?.resultId ?? ''" [data$]="data$" [sharableURL]="sharableURL" [statuses]="statuses" [actionsButton]="actionButtons" (refresh)="onRefresh()">
-  <mat-icon matListItemIcon aria-hidden="true" [fontIcon]="getPageIcon('results')"></mat-icon>
+  <mat-icon matListItemIcon aria-hidden="true" [fontIcon]="getIcon('results')"></mat-icon>
   <span i18n="Page title"> Result </span>
 </app-show-page>
   `,
@@ -54,13 +54,13 @@ export class ShowComponent extends AppShowComponent<ResultRaw, ResultsGrpcServic
     {
       id: 'session',
       name: $localize`See session`,
-      icon: this.getPageIcon('sessions'),
+      icon: this.getIcon('sessions'),
       link: '/sessions'
     },
     {
       id: 'task',
       name: $localize`See owner task`,
-      icon: this.getPageIcon('tasks'),
+      icon: this.getIcon('tasks'),
       link: '/tasks'
     }
   ];

--- a/src/app/services/icons.service.spec.ts
+++ b/src/app/services/icons.service.spec.ts
@@ -10,17 +10,8 @@ describe('IconsService', () => {
       expect(service.getIcon('arrow-down')).toEqual('arrow_drop_down');
     });
 
-    it('Should throw an error when the icon name is invalid', () => {
-      expect(() => {service.getIcon('this-icon-does-not-exists');})
-        .toThrowError('Icon \'this-icon-does-not-exists\' not found');
-    });
-  });
-
-  describe('getPageIcon', () => {
-    it('Should return the correct icon (3 tests)', () => {
-      expect(service.getPageIcon('applications')).toEqual('apps');
-      expect(service.getPageIcon('tasks')).toEqual('adjust');
-      expect(service.getPageIcon('profile')).toEqual('account_circle');
+    it('Should return the default icon if the icon is invalid', () => {
+      expect(service.getIcon('invalid-icon')).toEqual('radio_button_unchecked');
     });
   });
 

--- a/src/app/services/icons.service.ts
+++ b/src/app/services/icons.service.ts
@@ -1,23 +1,7 @@
 import { Injectable } from '@angular/core';
-import { Page } from '@app/types/pages';
 
 @Injectable()
 export class IconsService {
-  readonly pageIcons: Record<Page, string> = {
-    'applications': 'apps',
-    'partitions': 'donut_small',
-    'sessions': 'workspaces',
-    'tasks': 'adjust',
-    'results': 'workspace_premium',
-    'submitter': 'api',
-    'dashboard': 'dashboard',
-    'profile': 'account_circle',
-    'healthcheck': 'monitor_heart'
-    // TODO: rename page to 'permissions' (or endpoint)
-    // 'general': 'public',
-    // 'events': 'send',
-  };
-
   readonly icons: Record<string, string> = {
     'refresh': 'refresh',
     'auto-refresh': 'autorenew',
@@ -92,14 +76,10 @@ export class IconsService {
     const icon = this.icons[name];
 
     if (!icon) {
-      throw new Error(`Icon '${name}' not found`);
+      return this.icons['default'];
     }
 
     return this.icons[name];
-  }
-
-  getPageIcon(name: Page) {
-    return this.pageIcons[name];
   }
 
   getAllIcons() {

--- a/src/app/services/navigation.service.spec.ts
+++ b/src/app/services/navigation.service.spec.ts
@@ -70,7 +70,7 @@ describe('NavigationService', () => {
 
     it('Should restore the stored sideBar', () => {
       storedSideBar = ['applications', 'dashboard', 'divider', 'sessions'];
-      expect(service.restoreSidebar()).toBe(storedSideBar);
+      expect(service.restoreSidebar()).toEqual(storedSideBar);
     });
 
     it('Should restore default config sideBar if none is stored', () => {

--- a/src/app/services/navigation.service.ts
+++ b/src/app/services/navigation.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, inject } from '@angular/core';
 import { ExternalService } from '@app/types/external-service';
-import { Sidebar, SidebarItem, SidebarItems } from '@app/types/navigation';
+import { Sidebar, SidebarItem, SidebarItems, isSideBar } from '@app/types/navigation';
 import { DefaultConfigService } from './default-config.service';
 import { StorageService } from './storage.service';
 
@@ -84,7 +84,7 @@ export class NavigationService {
   restoreSidebar(): Sidebar[] {
     const sidebar = this.#storageService.getItem('navigation-sidebar', true) as Sidebar[] || this.#defaultConfigService.defaultSidebar;
 
-    return sidebar;
+    return sidebar.filter(element => isSideBar(element));
   }
 
   saveSidebar(sidebar: Sidebar[]) {

--- a/src/app/sessions/components/table.component.spec.ts
+++ b/src/app/sessions/components/table.component.spec.ts
@@ -188,7 +188,7 @@ describe('SessionsTableComponent', () => {
   });
 
   it('should get page icon', () => {
-    expect(component.getPageIcon('sessions')).toEqual('workspaces');
+    expect(component.getIcon('sessions')).toEqual('workspaces');
   });
 
   it('should create session id query params', () => {

--- a/src/app/sessions/components/table.component.ts
+++ b/src/app/sessions/components/table.component.ts
@@ -10,7 +10,6 @@ import { TaskSummaryFilters } from '@app/tasks/types';
 import { AbstractTableComponent, AbstractTaskByStatusTableComponent } from '@app/types/components/table';
 import {  ColumnKey, SessionData } from '@app/types/data';
 import { Filter } from '@app/types/filters';
-import { Page } from '@app/types/pages';
 import { ActionTable } from '@app/types/table';
 import { TableComponent } from '@components/table/table.component';
 import { FiltersService } from '@services/filters.service';
@@ -237,10 +236,6 @@ export class SessionsTableComponent extends AbstractTaskByStatusTableComponent<S
 
   getIcon(name: string): string {
     return this.iconsService.getIcon(name);
-  }
-
-  getPageIcon(page: Page): string {
-    return this.iconsService.getPageIcon(page);
   }
 
   onCopiedSessionId(data: SessionData) {

--- a/src/app/sessions/index.component.html
+++ b/src/app/sessions/index.component.html
@@ -1,5 +1,5 @@
 <app-page-header [sharableURL]="sharableURL">
-    <mat-icon matListItemIcon aria-hidden="true" [fontIcon]="getPageIcon('sessions')"></mat-icon>
+    <mat-icon matListItemIcon aria-hidden="true" [fontIcon]="getIcon('sessions')"></mat-icon>
     <span i18n="Page title"> Sessions </span>
   </app-page-header>
 

--- a/src/app/sessions/index.component.spec.ts
+++ b/src/app/sessions/index.component.spec.ts
@@ -227,10 +227,6 @@ describe('Sessions Index Component', () => {
     });
   });
 
-  it('should get page icon', () => {
-    expect(component.getPageIcon('sessions')).toEqual('workspaces');
-  });
-
   it('should get icons', () => {
     expect(component.getIcon('refresh')).toEqual('refresh');
   });

--- a/src/app/sessions/show.component.spec.ts
+++ b/src/app/sessions/show.component.spec.ts
@@ -104,10 +104,6 @@ describe('AppShowComponent', () => {
     });
   });
 
-  it('should get page icon', () => {
-    expect(component.getPageIcon('sessions')).toEqual('workspaces');
-  });
-
   it('should get icons', () => {
     expect(component.getIcon('refresh')).toEqual('refresh');
   });

--- a/src/app/sessions/show.component.ts
+++ b/src/app/sessions/show.component.ts
@@ -29,7 +29,7 @@ import { SessionRaw } from './types';
   selector: 'app-sessions-show',
   template: `
 <app-show-page [id]="data?.sessionId ?? ''" [data$]="data$" [sharableURL]="sharableURL" [statuses]="statuses" [actionsButton]="actionButtons" (refresh)="onRefresh()">
-  <mat-icon matListItemIcon aria-hidden="true" [fontIcon]="getPageIcon('sessions')"></mat-icon>
+  <mat-icon matListItemIcon aria-hidden="true" [fontIcon]="getIcon('sessions')"></mat-icon>
   <span i18n="Page title"> Session </span>
 </app-show-page>
   `,
@@ -88,21 +88,21 @@ export class ShowComponent extends AppShowComponent<SessionRaw, SessionsGrpcServ
     {
       id: 'tasks',
       name: $localize`See tasks`,
-      icon: this.getPageIcon('tasks'),
+      icon: this.getIcon('tasks'),
       link: '/tasks',
       queryParams: {},
     },
     {
       id: 'results',
       name: $localize`See results`,
-      icon: this.getPageIcon('results'),
+      icon: this.getIcon('results'),
       link: '/results',
       queryParams: {},
     },
     {
       id: 'partitions',
       name: $localize`See partitions`,
-      icon: this.getPageIcon('partitions'),
+      icon: this.getIcon('partitions'),
       link: '/partitions',
       queryParams: {},
     },

--- a/src/app/tasks/index.component.html
+++ b/src/app/tasks/index.component.html
@@ -1,5 +1,5 @@
 <app-page-header [sharableURL]="sharableURL">
-    <mat-icon matListItemIcon aria-hidden="true" [fontIcon]="getPageIcon('tasks')"></mat-icon>
+    <mat-icon matListItemIcon aria-hidden="true" [fontIcon]="getIcon('tasks')"></mat-icon>
     <span i18n="Page title"> Tasks </span>
   </app-page-header>
   

--- a/src/app/tasks/index.component.spec.ts
+++ b/src/app/tasks/index.component.spec.ts
@@ -243,10 +243,6 @@ describe('Tasks Index Component', () => {
     });
   });
 
-  it('should get page icon', () => {
-    expect(component.getPageIcon('tasks')).toEqual('adjust');
-  });
-
   it('should get icons', () => {
     expect(component.getIcon('refresh')).toEqual('refresh');
   });

--- a/src/app/tasks/show.component.spec.ts
+++ b/src/app/tasks/show.component.spec.ts
@@ -75,10 +75,6 @@ describe('AppShowComponent', () => {
     });
   });
 
-  it('should get page icon', () => {
-    expect(component.getPageIcon('tasks')).toEqual('adjust');
-  });
-
   it('should get icons', () => {
     expect(component.getIcon('refresh')).toEqual('refresh');
   });

--- a/src/app/tasks/show.component.ts
+++ b/src/app/tasks/show.component.ts
@@ -24,7 +24,7 @@ import { TaskRaw } from './types';
   selector: 'app-tasks-show',
   template: `
 <app-show-page [id]="data?.id ?? ''" [data$]="data$" [sharableURL]="sharableURL" [statuses]="statuses" [actionsButton]="actionButtons" (refresh)="onRefresh()">
-  <mat-icon matListItemIcon aria-hidden="true" [fontIcon]="getPageIcon('tasks')"></mat-icon>
+  <mat-icon matListItemIcon aria-hidden="true" [fontIcon]="getIcon('tasks')"></mat-icon>
   <span i18n="Page title"> Task </span>
 </app-show-page>
   `,
@@ -66,14 +66,14 @@ export class ShowComponent extends AppShowComponent<TaskRaw, TasksGrpcService> i
     {
       id: 'session',
       name: $localize`See session`,
-      icon: this.getPageIcon('sessions'),
+      icon: this.getIcon('sessions'),
       area: 'left',
       link: '/sessions',
     },
     {
       id: 'results',
       name: $localize`See results`,
-      icon: this.getPageIcon('results'),
+      icon: this.getIcon('results'),
       area: 'left',
       link: '/results',
       queryParams: {}
@@ -81,7 +81,7 @@ export class ShowComponent extends AppShowComponent<TaskRaw, TasksGrpcService> i
     {
       id: 'partition',
       name: $localize`See partition`,
-      icon: this.getPageIcon('partitions'),
+      icon: this.getIcon('partitions'),
       area: 'left',
       link: '/partitions',
     },

--- a/src/app/types/components/index.ts
+++ b/src/app/types/components/index.ts
@@ -11,7 +11,6 @@ import { ShareUrlService } from '@services/share-url.service';
 import { TableColumn } from '../column.type';
 import { CustomColumn, IndexListOptions, RawColumnKey, RawCustomColumnKey } from '../data';
 import { RawFilters } from '../filters';
-import { Page } from '../pages';
 import { FiltersServiceInterface } from '../services/filtersService';
 import { IndexServiceCustomInterface, IndexServiceInterface } from '../services/indexService';
 import { TableType } from '../table';
@@ -94,10 +93,6 @@ export abstract class TableHandler<K extends RawColumnKey, O extends IndexListOp
 
   updateDisplayedColumns(): void {
     this.displayedColumns = this.displayedColumnsKeys.map(key => this.indexService.availableTableColumns.find(column => column.key === key) as TableColumn<K>);
-  }
-
-  getPageIcon(name: Page): string {
-    return this.iconsService.getPageIcon(name);
   }
 
   getIcon(name: string): string {

--- a/src/app/types/components/show.ts
+++ b/src/app/types/components/show.ts
@@ -4,7 +4,6 @@ import { Subject, map, of } from 'rxjs';
 import { IconsService } from '@services/icons.service';
 import { NotificationService } from '@services/notification.service';
 import { ShareUrlService } from '@services/share-url.service';
-import { Page } from '../pages';
 import { GrpcService } from '../services';
 
 export type ShowActionButton = {
@@ -47,10 +46,6 @@ export abstract class AppShowComponent<T extends object, E extends GrpcService> 
   private _shareURLService = inject(ShareUrlService);
   private _notificationService = inject(NotificationService);
   private _route = inject(ActivatedRoute);
-
-  getPageIcon(page: Page): string {
-    return this._iconsService.getPageIcon(page);
-  }
 
   getIcon(name: string): string {
     return this._iconsService.getIcon(name);

--- a/src/app/types/navigation.ts
+++ b/src/app/types/navigation.ts
@@ -3,12 +3,13 @@
  *
  * A sidebar is build using a list of SidebarItems.
  */
+const ALL_SIDEBAR_LINKS = ['profile', 'dashboard', 'applications', 'sessions', 'partitions', 'results', 'tasks', 'healthcheck', 'divider'] as const;
 
+export type Sidebar = typeof ALL_SIDEBAR_LINKS[number];
 
-export type SidebarLinkName = 'profile' | 'dashboard' | 'applications' | 'sessions' | 'partitions' | 'results'  | 'tasks' | 'healthcheck' ;
-export type SidebarDivider = 'divider';
-
-export type Sidebar = SidebarLinkName | SidebarDivider;
+export function isSideBar(value: string): value is Sidebar {
+  return ALL_SIDEBAR_LINKS.includes(value as Sidebar);
+}
 
 export type SidebarLinkItem = {
   type: 'link';

--- a/src/app/types/pages.ts
+++ b/src/app/types/pages.ts
@@ -1,2 +1,0 @@
-// TODO: rename this because it's not application page but api endpoint (and permission)
-export type Page = 'applications' | 'partitions' | 'sessions' | 'tasks' | 'results' | 'submitter' | 'dashboard' | 'profile' | 'healthcheck';


### PR DESCRIPTION
This PR aims to simplify the navigations types. Plus, it allows a new type verification (isGroup, isSideBar) to avoid breaking changes on the setting pages.