### PR TITLE
feat: versions for gui configuration

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -56,12 +56,13 @@ function initializeAppFactory(userGrpcService: UserGrpcService, userService: Use
     ),
     httpClient.get<Partial<ExportedDefaultConfig>>('/static/gui_configuration').pipe(
       tap((data) => {
-        if (data) {
-          storageService.importConfigurationFromServer(data);
+        if (data && Object.keys(data).length !== 0) {
+          storageService.importData(data, false, false);
         }
       }),
-      catchError(() => {
-        console.warn('Server Config not found. Using default configuration.');
+      catchError((e) => {
+        console.warn('Server Config not found or invalid. Using default configuration.');
+        console.error(e);
         return of();
       })
     ),

--- a/src/app/services/storage.service.ts
+++ b/src/app/services/storage.service.ts
@@ -107,7 +107,7 @@ export class StorageService implements Storage {
       let dataToImport: string | object | undefined = undefined;
 
       parsedData.forEach((data) => {
-        if (data['version'] && (data['version'] as string).slice(0, -1) === pkg.version.slice(0, -1)) {
+        if (data['version'] && (data['version']).slice(0, -1) === pkg.version.slice(0, -1)) {
           dataToImport = data;
         }
       });
@@ -119,12 +119,10 @@ export class StorageService implements Storage {
         throw new Error('No data found for the current version');
       }
     }
-    else {
-      if (parsedData['version'] && (parsedData['version'] as string).slice(0, -1) === pkg.version.slice(0, -1)) {
-        this.#importDataObject(parsedData, override);
-      } else {
-        throw new Error('No data found for the current version');
-      }
+    else if (parsedData['version'] && (parsedData['version']).slice(0, -1) === pkg.version.slice(0, -1)) {
+      this.#importDataObject(parsedData, override);
+    } else {
+      throw new Error('No data found for the current version');
     }
   }
 


### PR DESCRIPTION
What's new ?

Now, when exporting the GUI configuration, the json will contain a `version` key, with the deployed version of the GUI.

This key is now ***required*** for the GUI to import a configuration, either if it comes from the user or from the server.

To be accepted, a configuration must have a key with the same `major` and `minor` versions.