### PR TITLE
feat: settings ux improvements

### DIFF
--- a/src/app/settings/component/clear-all-dialog.component.html
+++ b/src/app/settings/component/clear-all-dialog.component.html
@@ -1,0 +1,10 @@
+<h2 mat-dialog-title i18n="Dialog title" i18n>Clear all data</h2>
+
+<mat-dialog-content>
+  Are you sure you want to reset the configuration to its default settings ?
+</mat-dialog-content>
+
+<mat-dialog-actions align="end">
+  <button mat-button [mat-dialog-close]="false" i18n="Dialog action">Cancel</button>
+  <button mat-flat-button [mat-dialog-close]="true" color="primary" i18n="Dialog action"> Confirm </button>
+</mat-dialog-actions>

--- a/src/app/settings/component/clear-all-dialog.component.ts
+++ b/src/app/settings/component/clear-all-dialog.component.ts
@@ -1,0 +1,15 @@
+import { Component } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+import { MatDialogModule } from '@angular/material/dialog';
+
+@Component({
+  selector: 'app-clear-all-dialog',
+  standalone: true,
+  templateUrl: './clear-all-dialog.component.html',
+  imports: [
+    MatDialogModule,
+    MatButtonModule
+  ]
+})
+export class ClearAllDialogComponent {
+}

--- a/src/app/settings/index.component.html
+++ b/src/app/settings/index.component.html
@@ -62,7 +62,7 @@
           Delete data stored in your browser by this application. This will reset behavior and settings to their default values.
         </p>
   
-        <form (submit)="onSubmitStorage($event)">
+        <form (submit)="onSubmitStorage($event)" #storageForm>
   
           <ul *ngIf="keys.size; else noKey">
             <li *ngFor="let key of keys; trackBy:trackByKey">
@@ -74,10 +74,16 @@
   
           <div class="actions storage between">
             <div class="actions selection">
-              <button mat-flat-button color="warn" type="submit" i18n="Form" [disabled]="selectedKeys.size === 0">Clear</button>
-              <button mat-stroked-button type="reset" i18n="Form" [disabled]="selectedKeys.size === 0">Reset Selection</button>
+              <button mat-flat-button color="warn" type="submit" i18n="Form" [disabled]="selectedKeys.size === 0">
+                Clear
+              </button>
+              <button mat-stroked-button type="reset" i18n="Form" (click)="storageForm.reset();selectedKeys.clear()" [disabled]="selectedKeys.size === 0">
+                Reset Selection
+              </button>
             </div>
-            <button mat-stroked-button type="button" i18n="Form" (click)="clearAll()" [disabled]="keys.size === 0">Clear All</button>
+            <button mat-stroked-button type="button" i18n="Form" (click)="clearAll()" [disabled]="keys.size === 0">
+              Clear All
+            </button>
           </div>
         </form>
       </app-page-section>

--- a/src/app/settings/index.component.html
+++ b/src/app/settings/index.component.html
@@ -17,6 +17,14 @@
       <p i18n="Section description">
         Add, remove and reorder, using drap and drop, the items from the sidebar.
       </p>
+
+      <div class="actions navbar between">
+        <div class="actions">
+          <button mat-flat-button (click)="onSaveSidebar()" color="primary" type="button" i18n="Form">Save</button>
+          <button mat-stroked-button (click)="onResetSidebar()" type="button" i18n="Form">Reset</button>
+        </div>
+        <button mat-stroked-button (click)="onClearSideBar()" type="button" i18n="Form">Reset to default</button>
+      </div>
   
       <ul class="sidebar-items" cdkDropList (cdkDropListDropped)="drop($event)">
         <li cdkDrag *ngFor="let item of sidebar; let index = index; trackBy:trackBySidebarItem">
@@ -33,29 +41,15 @@
             </mat-select>
           </mat-form-field>
   
-          <button mat-icon-button aria-label="More options" mat-tooltip="More options" [matMenuTriggerFor]="menu">
-            <mat-icon aria-hidden="true" [fontIcon]="getIcon('more')"></mat-icon>
+          <button mat-icon-button (click)="onRemoveSidebarItem(index)">
+            <mat-icon aria-hidden="true" [fontIcon]="getIcon('delete')"/>
           </button>
-  
-          <mat-menu #menu="matMenu">
-            <button mat-menu-item (click)="onRemoveSidebarItem(index)">
-              <mat-icon aria-hidden="true" [fontIcon]="getIcon('delete')"></mat-icon>
-              <span i18n>Remove</span>
-            </button>
-          </mat-menu>
         </li>
+        <button class="add-sidebar-item" mat-stroked-button (click)="onAddSidebarItem()">
+          <mat-icon aria-hidden="true" [fontIcon]="getIcon('add')"></mat-icon>
+          <span i18n> Add an item </span>
+        </button>
       </ul>
-  
-      <button class="add-sidebar-item" mat-button (click)="onAddSidebarItem()">
-        <mat-icon aria-hidden="true" [fontIcon]="getIcon('add')"></mat-icon>
-        <span i18n> Add a status </span>
-      </button>
-  
-      <div class="actions">
-        <button mat-stroked-button (click)="onResetToDefaultSidebar()" type="button" i18n="Form">Reset to default</button>
-        <button mat-stroked-button (click)="onResetSidebar()" type="button" i18n="Form">Reset</button>
-        <button mat-flat-button (click)="onSaveSidebar()" color="primary" type="button" i18n="Form">Save</button>
-      </div>
     </app-page-section>
   
     <section>
@@ -72,16 +66,18 @@
   
           <ul *ngIf="keys.size; else noKey">
             <li *ngFor="let key of keys; trackBy:trackByKey">
-              <mat-checkbox [name]="key">
+              <mat-checkbox [name]="key" (change)="updateKeySelection($event)">
                 {{ key }}
               </mat-checkbox>
             </li>
           </ul>
   
-          <div class="actions">
-            <button mat-stroked-button type="reset" i18n="Form" [disabled]="keys.size === 0">Reset</button>
+          <div class="actions storage between">
+            <div class="actions selection">
+              <button mat-flat-button color="warn" type="submit" i18n="Form" [disabled]="selectedKeys.size === 0">Clear</button>
+              <button mat-stroked-button type="reset" i18n="Form" [disabled]="selectedKeys.size === 0">Reset Selection</button>
+            </div>
             <button mat-stroked-button type="button" i18n="Form" (click)="clearAll()" [disabled]="keys.size === 0">Clear All</button>
-            <button mat-flat-button color="warn" type="submit" i18n="Form" [disabled]="keys.size === 0">Clear</button>
           </div>
         </form>
       </app-page-section>
@@ -119,7 +115,7 @@
             <span>{{fileName}}</span>
           </div>
   
-          <div class="actions">
+          <div class="actions import">
             <button mat-stroked-button type="reset" i18n="Form">Reset</button>
             <button mat-flat-button color="primary" type="submit" i18n="Form">Import</button>
           </div>

--- a/src/app/settings/index.component.ts
+++ b/src/app/settings/index.component.ts
@@ -239,27 +239,12 @@ export class IndexComponent implements OnInit {
   onSubmitStorage(event: SubmitEvent): void {
     event.preventDefault();
 
-    const form = event.target as HTMLFormElement;
-
-    if (!form) {
-      return;
-    }
-
-    const checkboxes = form.querySelectorAll('input[type="checkbox"]');
-
-    const checkboxesArray = Array.from(checkboxes) as HTMLInputElement[];
-    const keys: Key[] = [];
-
-    for (const checkbox of checkboxesArray) {
-      if (checkbox.checked) {
-        keys.push(checkbox.name as Key);
-      }
-    }
-
-    for (const key of keys) {
+    for (const key of this.selectedKeys) {
       this.keys.delete(key);
       this.#storageService.removeItem(key);
     }
+
+    this.selectedKeys.clear();
 
     this.#notificationService.success('Data cleared');
   }

--- a/src/app/settings/index.component.ts
+++ b/src/app/settings/index.component.ts
@@ -3,7 +3,8 @@ import { NgFor, NgIf } from '@angular/common';
 import { HttpClient } from '@angular/common/http';
 import { Component, OnInit, inject } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
-import { MatCheckboxModule } from '@angular/material/checkbox';
+import { MatCheckboxChange, MatCheckboxModule } from '@angular/material/checkbox';
+import { MatDialog } from '@angular/material/dialog';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
@@ -21,6 +22,7 @@ import { NotificationService } from '@services/notification.service';
 import { QueryParamsService } from '@services/query-params.service';
 import { ShareUrlService } from '@services/share-url.service';
 import { StorageService } from '@services/storage.service';
+import { ClearAllDialogComponent } from './component/clear-all-dialog.component';
 
 @Component({
   selector: 'app-settings-index',
@@ -55,6 +57,7 @@ main {
 
 .add-sidebar-item {
   margin-top: 1rem;
+  width: 66%;
 }
 
 .storage ul {
@@ -83,11 +86,24 @@ main {
 }
 
 .actions {
-  margin-top: 1rem;
-
   display: flex;
-  flex-direction: row;
   gap: 1rem;
+}
+
+.between {
+  justify-content: space-between;
+}
+
+.storage {
+  margin-top: 1rem;
+}
+
+.import {
+  margin-top: 1rem;
+}
+
+.navbar {
+  margin-bottom: 1rem;
 }
 
 .cdk-drag-preview {
@@ -138,9 +154,11 @@ export class IndexComponent implements OnInit {
   sharableURL = '';
   fileName: string | undefined;
   keys: Set<Key> = new Set();
+  selectedKeys: Set<Key> = new Set();
 
   sidebar: Sidebar[] = [];
 
+  readonly dialog = inject(MatDialog);
   #iconsService = inject(IconsService);
   #shareURLService = inject(ShareUrlService);
   #notificationService = inject(NotificationService);
@@ -163,7 +181,16 @@ export class IndexComponent implements OnInit {
     this.sidebar = this.#navigationService.restoreSidebar();
   }
 
-  onResetToDefaultSidebar(): void {
+  onClearSideBar(): void {
+    const dialogRef = this.dialog.open<ClearAllDialogComponent>(ClearAllDialogComponent, {});
+    dialogRef.afterClosed().subscribe(result => {
+      if (result) {
+        this.clearSideBar();
+      }
+    });
+  }
+
+  clearSideBar(): void {
     this.sidebar = Array.from(this.#navigationService.defaultSidebar);
   }
 
@@ -201,6 +228,13 @@ export class IndexComponent implements OnInit {
     this.sidebar[index] = value;
   }
 
+  updateKeySelection(event: MatCheckboxChange): void {
+    if (this.selectedKeys.has(event.source.name as Key)) {
+      this.selectedKeys.delete(event.source.name as Key);
+    } else {
+      this.selectedKeys.add(event.source.name as Key);
+    }
+  }
 
   onSubmitStorage(event: SubmitEvent): void {
     event.preventDefault();
@@ -231,18 +265,30 @@ export class IndexComponent implements OnInit {
   }
 
   clearAll(): void {
+    const dialogRef = this.dialog.open<ClearAllDialogComponent>(ClearAllDialogComponent, {});
+
+    dialogRef.afterClosed().subscribe(result => {
+      if (result) {
+        this.#clearAll();
+        this.#getServerConfig();
+        this.#notificationService.success('All data cleared');
+      }
+    });
+  }
+
+  #clearAll(): void {
     for (const key of this.keys) {
       this.keys.delete(key);
       this.#storageService.removeItem(key);
     }
+  }
 
+  #getServerConfig() {
     this.httpClient.get<string>('/static/gui_configuration').subscribe(data => {
       if (data && Object.keys(data).length !== 0) {
         this.#storageService.importData(data as string, false, false);
       }
     });
-
-    this.#notificationService.success('All data cleared');
   }
 
   exportData(): void {


### PR DESCRIPTION
## Sidebar
The buttons for the sidebar configuration are located on the top of the editable sidebar and are displayed in a more logical order.
The `add a status` button has been renamed as `add an item` and is bigger.
The `Reset to default` button now use the `clear all` dialog.

## Storage
The buttons now have a more logical order. 
The buttons are disabled when nothing is selected.
The `Reset` button has been renamed to `Reset Selection`.
The `Clear All` button now use the `clear all` dialog.