### PR TITLE
feat: grpcTableClass

### DIFF
--- a/src/app/applications/components/table.component.ts
+++ b/src/app/applications/components/table.component.ts
@@ -16,7 +16,7 @@ import { NotificationService } from '@services/notification.service';
 import { TableTasksByStatus, TasksByStatusService } from '@services/tasks-by-status.service';
 import { ApplicationsGrpcService } from '../services/applications-grpc.service';
 import { ApplicationsIndexService } from '../services/applications-index.service';
-import { ApplicationRaw, ApplicationRawColumnKey, ApplicationRawFilters, ApplicationRawListOptions } from '../types';
+import { ApplicationRaw, ApplicationRawColumnKey, ApplicationRawFieldKey, ApplicationRawListOptions } from '../types';
 
 @Component({
   selector: 'app-application-table',
@@ -35,7 +35,8 @@ import { ApplicationRaw, ApplicationRawColumnKey, ApplicationRawFilters, Applica
     TableComponent,
   ]
 })
-export class ApplicationsTableComponent extends AbstractTaskByStatusTableComponent<ApplicationRaw, ApplicationRawColumnKey, ApplicationRawListOptions, ApplicationRawFilters> implements AfterViewInit {
+export class ApplicationsTableComponent extends AbstractTaskByStatusTableComponent<ApplicationRaw, ApplicationRawColumnKey, ApplicationRawFieldKey, ApplicationRawListOptions, ApplicationRawEnumField>
+  implements AfterViewInit {
   table: TableTasksByStatus = 'applications';
   
   readonly grpcService = inject(ApplicationsGrpcService);

--- a/src/app/applications/services/applications-grpc.service.spec.ts
+++ b/src/app/applications/services/applications-grpc.service.spec.ts
@@ -65,7 +65,6 @@ describe('ApplicationsGrpcService', () => {
 
   const mockApplicationsClient = {
     listApplications: jest.fn(),
-    getApplication: jest.fn(),
   };
 
   beforeEach(() => {
@@ -90,11 +89,18 @@ describe('ApplicationsGrpcService', () => {
       pageSize: options.pageSize,
       sort: {
         direction: 1,
-        fields: [{
-          applicationField: {
-            field: ApplicationRawEnumField.APPLICATION_RAW_ENUM_FIELD_NAME
+        fields: [
+          {
+            applicationField: {
+              field: ApplicationRawEnumField.APPLICATION_RAW_ENUM_FIELD_NAME
+            }
+          },
+          {
+            applicationField: {
+              field: ApplicationRawEnumField.APPLICATION_RAW_ENUM_FIELD_VERSION
+            }
           }
-        }]
+        ]
       },
       filters: {
         or: [
@@ -133,6 +139,26 @@ describe('ApplicationsGrpcService', () => {
     }));
   });
 
+  it('should sort with only one field and not two if not sorting by "name"', () => {
+    options.sort.active = 'version';
+    service.list$(options, []);
+    expect(mockApplicationsClient.listApplications).toHaveBeenCalledWith(new ListApplicationsRequest({
+      page: options.pageIndex,
+      pageSize: options.pageSize,
+      sort: {
+        direction: 1,
+        fields: [
+          {
+            applicationField: {
+              field: ApplicationRawEnumField.APPLICATION_RAW_ENUM_FIELD_VERSION
+            }
+          }
+        ]
+      },
+      filters: {or: []}
+    }));
+  });
+
   it('should throw on invalid filters', () => {
     const filters: ApplicationRawFilters = [[{
       field: ApplicationRawEnumField.APPLICATION_RAW_ENUM_FIELD_SERVICE,
@@ -158,11 +184,18 @@ describe('ApplicationsGrpcService', () => {
       pageSize: options.pageSize,
       sort: {
         direction: 1,
-        fields: [{
-          applicationField: {
-            field: ApplicationRawEnumField.APPLICATION_RAW_ENUM_FIELD_NAME
+        fields: [
+          {
+            applicationField: {
+              field: ApplicationRawEnumField.APPLICATION_RAW_ENUM_FIELD_NAME
+            }
+          },
+          {
+            applicationField: {
+              field: ApplicationRawEnumField.APPLICATION_RAW_ENUM_FIELD_VERSION
+            }
           }
-        }]
+        ]
       },
       filters: {}
     }));

--- a/src/app/applications/services/applications-grpc.service.spec.ts
+++ b/src/app/applications/services/applications-grpc.service.spec.ts
@@ -1,6 +1,6 @@
-import { ApplicationRawEnumField, ApplicationsClient, FilterStringOperator, ListApplicationsRequest } from '@aneoconsultingfr/armonik.api.angular';
+import { ApplicationRawEnumField, ApplicationsClient, FilterNumberOperator, FilterStatusOperator, FilterStringOperator, ListApplicationsRequest } from '@aneoconsultingfr/armonik.api.angular';
 import { TestBed } from '@angular/core/testing';
-import { FilterDefinitionRootString } from '@app/types/filter-definition';
+import { ListOptionsSort } from '@app/types/options';
 import { UtilsService } from '@services/utils.service';
 import { ApplicationsFiltersService } from './applications-filters.service';
 import { ApplicationsGrpcService } from './applications-grpc.service';
@@ -9,59 +9,72 @@ import { ApplicationRaw, ApplicationRawFilters, ApplicationRawListOptions } from
 describe('ApplicationsGrpcService', () => {
   let service: ApplicationsGrpcService;
 
-  const mockApplicationFiltersService = {
-    filtersDefinitions: [
+  const filters: ApplicationRawFilters = [
+    [
       {
+        field: ApplicationRawEnumField.APPLICATION_RAW_ENUM_FIELD_NAME,
         for: 'root',
-        field: 1,
-        type: 'string'
+        operator: FilterStringOperator.FILTER_STRING_OPERATOR_EQUAL,
+        value: 'applicationId'
+      },
+    ],
+    [
+      {
+        field: ApplicationRawEnumField.APPLICATION_RAW_ENUM_FIELD_VERSION,
+        for: 'root',
+        operator: FilterStringOperator.FILTER_STRING_OPERATOR_ENDS_WITH,
+        value: 100
       },
       {
+        field: null,
         for: 'root',
-        field: 2,
-        type: 'number'
-      } as unknown as FilterDefinitionRootString<ApplicationRawEnumField>
+        operator: FilterNumberOperator.FILTER_NUMBER_OPERATOR_LESS_THAN_OR_EQUAL,
+        value: 29
+      }
     ]
-  };
-  
-  const mockApplicationsClient = {
-    listApplications: jest.fn().mockImplementation((data) => data)
-  };
+  ];
 
   const options: ApplicationRawListOptions = {
-    pageIndex: 0,
+    pageIndex: 2,
     pageSize: 10,
     sort: {
-      active: 'version',
+      active: 'name',
       direction: 'asc'
     }
   };
 
-  const correctfilters: ApplicationRawFilters = [[
-    {
-      field: 1,
-      for: 'root',
-      operator: 0,
-      value: 'someValue'
-    }
-  ]];
+  const mockApplicationsFiltersService = {
+    filtersDefinitions: [
+      {
+        for: 'root',
+        field: ApplicationRawEnumField.APPLICATION_RAW_ENUM_FIELD_NAME,
+        type: 'string'
+      },
+      {
+        for: 'root',
+        field: ApplicationRawEnumField.APPLICATION_RAW_ENUM_FIELD_VERSION,
+        type: 'string',
+      },
+      {
+        for: 'root',
+        field: ApplicationRawEnumField.APPLICATION_RAW_ENUM_FIELD_SERVICE,
+        type: 'status',
+      },
+    ],
+  };
 
-  const uncorrectfilters: ApplicationRawFilters = [[
-    {
-      field: 2,
-      for: 'root',
-      operator: 0,
-      value: 123
-    }
-  ]];
+  const mockApplicationsClient = {
+    listApplications: jest.fn(),
+    getApplication: jest.fn(),
+  };
 
   beforeEach(() => {
     service = TestBed.configureTestingModule({
       providers: [
         ApplicationsGrpcService,
-        UtilsService<ApplicationRawEnumField>,
-        { provide: ApplicationsClient, useValue: mockApplicationsClient },
-        { provide: ApplicationsFiltersService, useValue: mockApplicationFiltersService }
+        UtilsService,
+        { provide: ApplicationsFiltersService, useValue: mockApplicationsFiltersService },
+        { provide: ApplicationsClient, useValue: mockApplicationsClient }
       ]
     }).inject(ApplicationsGrpcService);
   });
@@ -70,122 +83,88 @@ describe('ApplicationsGrpcService', () => {
     expect(service).toBeTruthy();
   });
 
-  it('should create a request without filters', () => {
-    const listResult = new ListApplicationsRequest({
-      page: 0,
-      pageSize: 10,
+  it('should list applications', () => {
+    service.list$(options, filters);
+    expect(mockApplicationsClient.listApplications).toHaveBeenCalledWith(new ListApplicationsRequest({
+      page: options.pageIndex,
+      pageSize: options.pageSize,
       sort: {
         direction: 1,
         fields: [{
           applicationField: {
-            field: 2
+            field: ApplicationRawEnumField.APPLICATION_RAW_ENUM_FIELD_NAME
           }
         }]
       },
-      filters: {or: []}
-    });
-    expect(service.list$(options, [])).toEqual(listResult);
-  });
-
-  it('should create a request with filters', () => {
-    const listResult = new ListApplicationsRequest({
-      page: 0,
-      pageSize: 10,
-      sort: {
-        direction: 1,
-        fields: [{
-          applicationField: {
-            field: 2
-          }
-        }]
-      },
-      filters: { or: [{
-        and: [{
-          field: {
-            applicationField: {
-              field: 1
-            }
+      filters: {
+        or: [
+          {
+            and: [
+              {
+                field: {
+                  applicationField: {
+                    field: ApplicationRawEnumField.APPLICATION_RAW_ENUM_FIELD_NAME
+                  }
+                },
+                filterString: {
+                  operator: FilterStringOperator.FILTER_STRING_OPERATOR_EQUAL,
+                  value: 'applicationId'
+                }
+              },
+            ]
           },
-          filterString: {
-            value: 'someValue',
-            operator: 0 as FilterStringOperator
+          {
+            and: [
+              {
+                field: {
+                  applicationField: {
+                    field: ApplicationRawEnumField.APPLICATION_RAW_ENUM_FIELD_VERSION
+                  }
+                },
+                filterString: {
+                  operator: FilterStringOperator.FILTER_STRING_OPERATOR_ENDS_WITH,
+                  value: '100'
+                }
+              }
+            ]
           }
-        }]
-      }]}
-    });
-    expect(service.list$(options, correctfilters)).toEqual(listResult);
+        ]
+      }
+    }));
   });
 
-  it('should throw error in case on unexpected type', () => {
-    expect(() => {service.list$(options, uncorrectfilters);}).toThrow('Type number not supported');
+  it('should throw on invalid filters', () => {
+    const filters: ApplicationRawFilters = [[{
+      field: ApplicationRawEnumField.APPLICATION_RAW_ENUM_FIELD_SERVICE,
+      for: 'root',
+      operator: FilterStatusOperator.FILTER_STATUS_OPERATOR_EQUAL,
+      value: 0
+    }]];
+    expect(() => service.list$(options, filters)).toThrow('Type status not supported');
   });
 
-  it('should throw error in case on unexpected sort field', () => {
-    options.sort.active = 'unexpected' as unknown as keyof ApplicationRaw;
-    expect(() => {service.list$(options, []);}).toThrow('Sort field "unexpected" not supported');
-  });
-
-  describe('getSortFieldsArray', () => {
-    const requestObject = {
-      page: 0,
+  it('should have a default sort field direction', () => {
+    const options: ApplicationRawListOptions = {
+      pageIndex: 10,
       pageSize: 10,
       sort: {
-        direction: 1,
-        fields: [] as {applicationField: {field: ApplicationRawEnumField}}[],
-      },
-      filters: {or: []}
+        active: null,
+        direction: 'asc'
+      } as unknown as ListOptionsSort<ApplicationRaw>
     };
-
-    it('should create the correct sorting field for "name"', () => {
-      options.sort.active = 'name';
-      requestObject.sort.fields = [
-        {
+    service.list$(options, [[]]);
+    expect(mockApplicationsClient.listApplications).toHaveBeenCalledWith(new ListApplicationsRequest({
+      page: options.pageIndex,
+      pageSize: options.pageSize,
+      sort: {
+        direction: 1,
+        fields: [{
           applicationField: {
-            field: 1
+            field: ApplicationRawEnumField.APPLICATION_RAW_ENUM_FIELD_NAME
           }
-        },
-        {
-          applicationField: {
-            field: 2
-          }
-        }
-      ];
-      expect(service.list$(options, [])).toEqual(new ListApplicationsRequest(requestObject));
-    });
-
-    it('should create the correct sorting field for "version"', () => {
-      options.sort.active = 'version';
-      requestObject.sort.fields = [{
-        applicationField: {
-          field: 2
-        }
-      }];
-      expect(service.list$(options, [])).toEqual(new ListApplicationsRequest(requestObject));
-    });
-  
-    it('should create the correct sorting field for "namespace"', () => {
-      options.sort.active = 'namespace';
-      requestObject.sort.fields = [{
-        applicationField: {
-          field: 3
-        }
-      }];
-      expect(service.list$(options, [])).toEqual(new ListApplicationsRequest(requestObject));
-    });
-  
-    it('should create the correct sorting field for "service"', () => {
-      options.sort.active = 'service';
-      requestObject.sort.fields = [{
-        applicationField: {
-          field: 4
-        }
-      }];
-      expect(service.list$(options, [])).toEqual(new ListApplicationsRequest(requestObject));
-    });
-
-    it('should throw error in case of an unexpected sort field', () => {
-      options.sort.active = 'unexpected' as unknown as keyof ApplicationRaw;
-      expect(() => {service.list$(options, []);}).toThrow('Sort field "unexpected" not supported');
-    });
+        }]
+      },
+      filters: {}
+    }));
   });
 });

--- a/src/app/applications/services/applications-grpc.service.ts
+++ b/src/app/applications/services/applications-grpc.service.ts
@@ -40,14 +40,16 @@ export class ApplicationsGrpcService extends GrpcTableService<ApplicationRawFiel
           }
         ]
       };
-    } else {
+    } else if (this.sortFields[field]) {
       return {
         fields: [{
           applicationField: {
-            field: field
+            field: this.sortFields[field]
           }
         }]
       };
+    } else {
+      return this.createSortField('name');
     }
   }
 

--- a/src/app/applications/services/applications-grpc.service.ts
+++ b/src/app/applications/services/applications-grpc.service.ts
@@ -12,7 +12,6 @@ export class ApplicationsGrpcService extends GrpcTableService<ApplicationRawFiel
   readonly filterService = inject(ApplicationsFiltersService);
   readonly grpcClient = inject(ApplicationsClient);
 
-  readonly defaultSortField = ApplicationRawEnumField.APPLICATION_RAW_ENUM_FIELD_NAME;
   readonly sortFields: Record<ApplicationRawFieldKey, ApplicationRawEnumField> = {
     'name': ApplicationRawEnumField.APPLICATION_RAW_ENUM_FIELD_NAME,
     'namespace': ApplicationRawEnumField.APPLICATION_RAW_ENUM_FIELD_NAMESPACE,
@@ -25,8 +24,8 @@ export class ApplicationsGrpcService extends GrpcTableService<ApplicationRawFiel
     return this.grpcClient.listApplications(request);
   }
 
-  createSortField(field: ApplicationRawEnumField): ListApplicationSortField {
-    if (field === ApplicationRawEnumField.APPLICATION_RAW_ENUM_FIELD_NAME) {
+  createSortField(field: ApplicationRawFieldKey): ListApplicationSortField {
+    if (field === 'name') {
       return {
         fields: [
           {

--- a/src/app/dashboard/types.ts
+++ b/src/app/dashboard/types.ts
@@ -1,4 +1,4 @@
-import { ApplicationRawEnumField, PartitionRawEnumField, ResultRawEnumField, SessionRawEnumField, TaskOptionEnumField, TaskStatus, TaskSummaryEnumField } from '@aneoconsultingfr/armonik.api.angular';
+import { ApplicationRawEnumField, PartitionRawEnumField, ResultRawEnumField, SessionRawEnumField, SessionTaskOptionEnumField, TaskOptionEnumField, TaskStatus, TaskSummaryEnumField } from '@aneoconsultingfr/armonik.api.angular';
 import { ApplicationRaw, ApplicationRawFilters } from '@app/applications/types';
 import { PartitionRaw } from '@app/partitions/types';
 import { ResultRaw } from '@app/results/types';
@@ -12,7 +12,7 @@ export type LineType = TableType | 'CountStatus';
 export type Summary = TaskSummary | ApplicationRaw | PartitionRaw | SessionRaw | ResultRaw;
 export type SummaryOptions = TaskOptions;
 export type FiltersEnums = ApplicationRawEnumField | PartitionRawEnumField | SessionRawEnumField | TaskSummaryEnumField | ResultRawEnumField;
-export type FiltersOptionsEnums = TaskOptionEnumField | null;
+export type FiltersOptionsEnums = SessionTaskOptionEnumField | TaskOptionEnumField | null;
 
 export type Line = {
   name: string,

--- a/src/app/partitions/components/table.component.ts
+++ b/src/app/partitions/components/table.component.ts
@@ -10,7 +10,7 @@ import { GrpcSortFieldService } from '@services/grpc-sort-field.service';
 import { TableTasksByStatus, TasksByStatusService } from '@services/tasks-by-status.service';
 import { PartitionsGrpcService } from '../services/partitions-grpc.service';
 import { PartitionsIndexService } from '../services/partitions-index.service';
-import { PartitionRaw, PartitionRawColumnKey, PartitionRawFilters, PartitionRawListOptions } from '../types';
+import { PartitionRaw, PartitionRawColumnKey, PartitionRawFieldKey, PartitionRawListOptions } from '../types';
 
 @Component({
   selector: 'app-partitions-table',
@@ -27,7 +27,8 @@ import { PartitionRaw, PartitionRawColumnKey, PartitionRawFilters, PartitionRawL
     TableComponent,
   ]
 })
-export class PartitionsTableComponent extends AbstractTaskByStatusTableComponent<PartitionRaw, PartitionRawColumnKey, PartitionRawListOptions, PartitionRawFilters> implements AfterViewInit {
+export class PartitionsTableComponent extends AbstractTaskByStatusTableComponent<PartitionRaw, PartitionRawColumnKey, PartitionRawFieldKey, PartitionRawListOptions, PartitionRawEnumField>
+  implements AfterViewInit {
   
   readonly grpcService = inject(PartitionsGrpcService);
   readonly indexService = inject(PartitionsIndexService);

--- a/src/app/partitions/services/partitions-grpc.service.spec.ts
+++ b/src/app/partitions/services/partitions-grpc.service.spec.ts
@@ -30,6 +30,12 @@ describe('PartitionsGrpcService', () => {
         for: 'root',
         operator: FilterNumberOperator.FILTER_NUMBER_OPERATOR_LESS_THAN,
         value: 100
+      },
+      {
+        field: null,
+        for: 'root',
+        operator: FilterNumberOperator.FILTER_NUMBER_OPERATOR_LESS_THAN_OR_EQUAL,
+        value: 29
       }
     ]
   ];

--- a/src/app/partitions/services/partitions-grpc.service.ts
+++ b/src/app/partitions/services/partitions-grpc.service.ts
@@ -41,7 +41,7 @@ export class PartitionsGrpcService extends GrpcTableService<PartitionRawFieldKey
     return {
       field: {
         partitionRawField: {
-          field: this.sortFields[field as PartitionRawFieldKey] ?? PartitionRawEnumField.PARTITION_RAW_ENUM_FIELD_ID
+          field: this.sortFields[field] ?? PartitionRawEnumField.PARTITION_RAW_ENUM_FIELD_ID
         }
       }
     };

--- a/src/app/partitions/services/partitions-grpc.service.ts
+++ b/src/app/partitions/services/partitions-grpc.service.ts
@@ -14,7 +14,6 @@ export class PartitionsGrpcService extends GrpcTableService<PartitionRawFieldKey
   readonly filterService = inject(PartitionsFiltersService);
   readonly grpcClient = inject(PartitionsClient);
 
-  readonly defaultSortField = PartitionRawEnumField.PARTITION_RAW_ENUM_FIELD_ID;
   readonly sortFields: Record<PartitionRawFieldKey, PartitionRawEnumField> = {
     'id': PartitionRawEnumField.PARTITION_RAW_ENUM_FIELD_ID,
     'parentPartitionIds': PartitionRawEnumField.PARTITION_RAW_ENUM_FIELD_PARENT_PARTITION_IDS,
@@ -38,11 +37,11 @@ export class PartitionsGrpcService extends GrpcTableService<PartitionRawFieldKey
     return this.grpcClient.getPartition(getPartitionRequest);
   }
 
-  createSortField(field: PartitionRawEnumField): ListDefaultSortField {
+  createSortField(field: PartitionRawFieldKey): ListDefaultSortField {
     return {
       field: {
         partitionRawField: {
-          field
+          field: this.sortFields[field as PartitionRawFieldKey] ?? PartitionRawEnumField.PARTITION_RAW_ENUM_FIELD_ID
         }
       }
     };

--- a/src/app/partitions/services/partitions-grpc.service.ts
+++ b/src/app/partitions/services/partitions-grpc.service.ts
@@ -1,20 +1,20 @@
 import { GetPartitionRequest, GetPartitionResponse, ListPartitionsRequest, ListPartitionsResponse, PartitionFilterField, PartitionRawEnumField, PartitionsClient } from '@aneoconsultingfr/armonik.api.angular';
 import { Injectable, inject } from '@angular/core';
 import { Observable } from 'rxjs';
-import { FilterType } from '@app/types/filters';
-import { GrpcGetInterface, GrpcListInterface } from '@app/types/services/grpcService';
-import { buildArrayFilter, buildNumberFilter, buildStringFilter, sortDirections } from '@services/grpc-build-request.service';
-import { UtilsService } from '@services/utils.service';
+import { Filter, FilterType } from '@app/types/filters';
+import { GrpcGetInterface, GrpcTableService, ListDefaultSortField, RequestFilterField } from '@app/types/services/grpcService';
+import { FilterField, buildArrayFilter, buildNumberFilter, buildStringFilter } from '@services/grpc-build-request.service';
 import { PartitionsFiltersService } from './partitions-filters.service';
-import { PartitionRawFieldKey, PartitionRawFilter, PartitionRawFilters, PartitionRawListOptions } from '../types';
+import { PartitionRawFieldKey, PartitionRawFilters, PartitionRawListOptions } from '../types';
 
 
 @Injectable()
-export class PartitionsGrpcService implements GrpcListInterface<PartitionsClient, PartitionRawListOptions, PartitionRawFilters, PartitionRawFieldKey, PartitionRawEnumField>, GrpcGetInterface<GetPartitionResponse> {
+export class PartitionsGrpcService extends GrpcTableService<PartitionRawFieldKey, PartitionRawListOptions, PartitionRawEnumField>
+  implements GrpcGetInterface<GetPartitionResponse> {
   readonly filterService = inject(PartitionsFiltersService);
   readonly grpcClient = inject(PartitionsClient);
-  readonly utilsService = inject(UtilsService<PartitionRawEnumField>);
 
+  readonly defaultSortField = PartitionRawEnumField.PARTITION_RAW_ENUM_FIELD_ID;
   readonly sortFields: Record<PartitionRawFieldKey, PartitionRawEnumField> = {
     'id': PartitionRawEnumField.PARTITION_RAW_ENUM_FIELD_ID,
     'parentPartitionIds': PartitionRawEnumField.PARTITION_RAW_ENUM_FIELD_PARENT_PARTITION_IDS,
@@ -26,26 +26,11 @@ export class PartitionsGrpcService implements GrpcListInterface<PartitionsClient
   };
 
   list$(options: PartitionRawListOptions, filters: PartitionRawFilters): Observable<ListPartitionsResponse> {
-    const requestFilters = this.utilsService.createFilters<PartitionFilterField.AsObject>(filters, this.filterService.filtersDefinitions, this.#buildFilterField);
-
-    const listPartitionsRequest = new ListPartitionsRequest({
-      page: options.pageIndex,
-      pageSize: options.pageSize,
-      sort: {
-        direction: sortDirections[options.sort.direction],
-        field: {
-          partitionRawField: {
-            field: this.sortFields[options.sort.active] ?? PartitionRawEnumField.PARTITION_RAW_ENUM_FIELD_ID
-          }
-        }
-      },
-      filters: requestFilters
-    });
-
+    const listPartitionsRequest = new ListPartitionsRequest(this.createListRequest(options, filters) as ListPartitionsRequest);
     return this.grpcClient.listPartitions(listPartitionsRequest);
   }
 
-  get$(id: string) :Observable<GetPartitionResponse> {
+  get$(id: string): Observable<GetPartitionResponse> {
     const getPartitionRequest = new GetPartitionRequest({
       id
     });
@@ -53,26 +38,35 @@ export class PartitionsGrpcService implements GrpcListInterface<PartitionsClient
     return this.grpcClient.getPartition(getPartitionRequest);
   }
 
-  #buildFilterField(filter: PartitionRawFilter) {
-    return (type: FilterType, field: PartitionRawEnumField) => {
-
-      const filterField = {
+  createSortField(field: PartitionRawEnumField): ListDefaultSortField {
+    return {
+      field: {
         partitionRawField: {
           field
         }
-      } satisfies PartitionFilterField.AsObject['field'];
-
-      switch (type) {
-      case 'string':
-        return buildStringFilter(filterField, filter) as PartitionFilterField.AsObject;
-      case 'number':
-        return buildNumberFilter(filterField, filter) as PartitionFilterField.AsObject;
-      case 'array':
-        return buildArrayFilter(filterField, filter) as PartitionFilterField.AsObject;
-      default: {
-        throw new Error(`Type ${type} not supported`);
-      }
       }
     };
+  }
+
+  createFilterField(field: PartitionRawEnumField) {
+    return {
+      partitionRawField: {
+        field
+      }
+    } satisfies PartitionFilterField.AsObject['field'];
+  }
+
+  buildFilter(type: FilterType, filterField: FilterField, filter: Filter<PartitionRawEnumField, null>): RequestFilterField {
+    switch (type) {
+    case 'string':
+      return buildStringFilter(filterField, filter) as PartitionFilterField.AsObject;
+    case 'number':
+      return buildNumberFilter(filterField, filter) as PartitionFilterField.AsObject;
+    case 'array':
+      return buildArrayFilter(filterField, filter) as PartitionFilterField.AsObject;
+    default: {
+      throw new Error(`Type ${type} not supported`);
+    }
+    }
   }
 }

--- a/src/app/partitions/show.component.ts
+++ b/src/app/partitions/show.component.ts
@@ -1,4 +1,4 @@
-import { FilterArrayOperator, FilterStringOperator, SessionRawEnumField, TaskOptionEnumField } from '@aneoconsultingfr/armonik.api.angular';
+import { FilterArrayOperator, FilterStringOperator, PartitionRawEnumField, SessionRawEnumField, TaskOptionEnumField } from '@aneoconsultingfr/armonik.api.angular';
 import { AfterViewInit, Component, OnInit, inject } from '@angular/core';
 import { MatIconModule } from '@angular/material/icon';
 import { MatSnackBar } from '@angular/material/snack-bar';
@@ -15,7 +15,7 @@ import { TableService } from '@services/table.service';
 import { UtilsService } from '@services/utils.service';
 import { PartitionsFiltersService } from './services/partitions-filters.service';
 import { PartitionsGrpcService } from './services/partitions-grpc.service';
-import { PartitionRaw } from './types';
+import { PartitionRaw, PartitionRawFieldKey, PartitionRawListOptions } from './types';
 
 @Component({
   selector: 'app-partitions-show',
@@ -46,7 +46,7 @@ import { PartitionRaw } from './types';
     MatIconModule
   ]
 })
-export class ShowComponent extends AppShowComponent<PartitionRaw, PartitionsGrpcService> implements OnInit, AfterViewInit, ShowActionInterface {
+export class ShowComponent extends AppShowComponent<PartitionRaw, PartitionRawFieldKey, PartitionRawListOptions, PartitionRawEnumField> implements OnInit, AfterViewInit, ShowActionInterface {
   protected override _grpcService = inject(PartitionsGrpcService);
   private _filtersService = inject(FiltersService);
 

--- a/src/app/results/components/table.component.ts
+++ b/src/app/results/components/table.component.ts
@@ -1,4 +1,4 @@
-import { FilterStringOperator, ListResultsResponse, SessionRawEnumField } from '@aneoconsultingfr/armonik.api.angular';
+import { FilterStringOperator, ListResultsResponse, ResultRawEnumField, SessionRawEnumField } from '@aneoconsultingfr/armonik.api.angular';
 import { AfterViewInit, Component, inject } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { Subject } from 'rxjs';
@@ -12,7 +12,7 @@ import { ResultsFiltersService } from '../services/results-filters.service';
 import { ResultsGrpcService } from '../services/results-grpc.service';
 import { ResultsIndexService } from '../services/results-index.service';
 import { ResultsStatusesService } from '../services/results-statuses.service';
-import { ResultRaw, ResultRawColumnKey, ResultRawFilters, ResultRawListOptions } from '../types';
+import { ResultRaw, ResultRawColumnKey, ResultRawFieldKey, ResultRawListOptions } from '../types';
 
 @Component({
   selector: 'app-results-table',
@@ -32,7 +32,8 @@ import { ResultRaw, ResultRawColumnKey, ResultRawFilters, ResultRawListOptions }
     TableComponent,
   ]
 })
-export class ResultsTableComponent extends AbstractTableComponent<ResultRaw, ResultRawColumnKey, ResultRawListOptions, ResultRawFilters> implements AfterViewInit {
+export class ResultsTableComponent extends AbstractTableComponent<ResultRaw, ResultRawColumnKey, ResultRawFieldKey, ResultRawListOptions, ResultRawEnumField>
+  implements AfterViewInit {
   readonly grpcService = inject(ResultsGrpcService);
   readonly indexService = inject(ResultsIndexService);
   readonly statusesService = inject(ResultsStatusesService);

--- a/src/app/results/services/results-grpc.service.spec.ts
+++ b/src/app/results/services/results-grpc.service.spec.ts
@@ -37,6 +37,12 @@ describe('ResultsGrpcService', () => {
         for: 'root',
         operator: FilterNumberOperator.FILTER_NUMBER_OPERATOR_LESS_THAN,
         value: 100
+      },
+      {
+        field: null,
+        for: 'root',
+        operator: FilterNumberOperator.FILTER_NUMBER_OPERATOR_LESS_THAN_OR_EQUAL,
+        value: 29
       }
     ]
   ];

--- a/src/app/results/services/results-grpc.service.ts
+++ b/src/app/results/services/results-grpc.service.ts
@@ -42,7 +42,7 @@ export class ResultsGrpcService extends GrpcTableService<ResultRawFieldKey, Resu
     return {
       field: {
         resultRawField: {
-          field: this.sortFields[field as ResultRawFieldKey] ?? ResultRawEnumField.RESULT_RAW_ENUM_FIELD_RESULT_ID
+          field: this.sortFields[field] ?? ResultRawEnumField.RESULT_RAW_ENUM_FIELD_RESULT_ID
         }
       }
     };

--- a/src/app/results/services/results-grpc.service.ts
+++ b/src/app/results/services/results-grpc.service.ts
@@ -11,8 +11,6 @@ import { ResultRawFieldKey, ResultRawFilters, ResultRawListOptions } from '../ty
 export class ResultsGrpcService extends GrpcTableService<ResultRawFieldKey, ResultRawListOptions, ResultRawEnumField>
   implements GrpcGetInterface<GetResultResponse> {
 
-  readonly defaultSortField = ResultRawEnumField.RESULT_RAW_ENUM_FIELD_RESULT_ID;
-
   readonly filterService = inject(ResultsFiltersService);
   readonly grpcClient = inject(ResultsClient);
 
@@ -40,11 +38,11 @@ export class ResultsGrpcService extends GrpcTableService<ResultRawFieldKey, Resu
     return this.grpcClient.getResult(getResultRequest);
   }
 
-  createSortField(field: ResultRawEnumField): ListDefaultSortField {
+  createSortField(field: ResultRawFieldKey): ListDefaultSortField {
     return {
       field: {
         resultRawField: {
-          field: field
+          field: this.sortFields[field as ResultRawFieldKey] ?? ResultRawEnumField.RESULT_RAW_ENUM_FIELD_RESULT_ID
         }
       }
     };

--- a/src/app/results/services/results-grpc.service.ts
+++ b/src/app/results/services/results-grpc.service.ts
@@ -1,17 +1,19 @@
 import { GetResultRequest, GetResultResponse, ListResultsRequest, ListResultsResponse, ResultFilterField, ResultRawEnumField, ResultsClient } from '@aneoconsultingfr/armonik.api.angular';
 import { Injectable, inject } from '@angular/core';
 import { Observable } from 'rxjs';
-import { FilterType } from '@app/types/filters';
-import { GrpcGetInterface, GrpcListInterface } from '@app/types/services/grpcService';
-import { buildDateFilter, buildNumberFilter, buildStatusFilter, buildStringFilter, sortDirections } from '@services/grpc-build-request.service';
-import { UtilsService } from '@services/utils.service';
+import { Filter, FilterType } from '@app/types/filters';
+import { GrpcGetInterface, GrpcTableService, ListDefaultSortField } from '@app/types/services/grpcService';
+import { FilterField, buildDateFilter, buildNumberFilter, buildStatusFilter, buildStringFilter } from '@services/grpc-build-request.service';
 import { ResultsFiltersService } from './results-filters.service';
-import {  ResultRawFieldKey, ResultRawFilter, ResultRawFilters, ResultRawListOptions } from '../types';
+import { ResultRawFieldKey, ResultRawFilters, ResultRawListOptions } from '../types';
 
 @Injectable()
-export class ResultsGrpcService implements GrpcListInterface<ResultsClient, ResultRawListOptions, ResultRawFilters, ResultRawFieldKey, ResultRawEnumField>, GrpcGetInterface<GetResultResponse> {
+export class ResultsGrpcService extends GrpcTableService<ResultRawFieldKey, ResultRawListOptions, ResultRawEnumField>
+  implements GrpcGetInterface<GetResultResponse> {
+
+  readonly defaultSortField = ResultRawEnumField.RESULT_RAW_ENUM_FIELD_RESULT_ID;
+
   readonly filterService = inject(ResultsFiltersService);
-  readonly utilsService = inject(UtilsService<ResultRawEnumField>);
   readonly grpcClient = inject(ResultsClient);
 
   readonly sortFields: Record<ResultRawFieldKey, ResultRawEnumField> = {
@@ -26,23 +28,7 @@ export class ResultsGrpcService implements GrpcListInterface<ResultsClient, Resu
   };
 
   list$(options: ResultRawListOptions, filters: ResultRawFilters): Observable<ListResultsResponse> {
-
-    const requestFilters = this.utilsService.createFilters<ResultFilterField.AsObject>(filters, this.filterService.filtersDefinitions, this.#buildFilterField);
-
-    const listResultRequest = new ListResultsRequest({
-      page: options.pageIndex,
-      pageSize: options.pageSize,
-      sort: {
-        direction: sortDirections[options.sort.direction],
-        field: {
-          resultRawField: {
-            field: this.sortFields[options.sort.active] ?? ResultRawEnumField.RESULT_RAW_ENUM_FIELD_RESULT_ID
-          }
-        }
-      },
-      filters: requestFilters
-    });
-
+    const listResultRequest = new ListResultsRequest(this.createListRequest(options, filters) as ListResultsRequest);
     return this.grpcClient.listResults(listResultRequest);
   }
 
@@ -54,28 +40,37 @@ export class ResultsGrpcService implements GrpcListInterface<ResultsClient, Resu
     return this.grpcClient.getResult(getResultRequest);
   }
 
-  #buildFilterField(filter: ResultRawFilter) {
-    return (type: FilterType, field: ResultRawEnumField) => {
-
-      const filterField = {
+  createSortField(field: ResultRawEnumField): ListDefaultSortField {
+    return {
+      field: {
         resultRawField: {
-          field: field as ResultRawEnumField
+          field: field
         }
-      } satisfies ResultFilterField.AsObject['field'];
-
-      switch (type) {
-      case 'string':
-        return buildStringFilter(filterField, filter) as ResultFilterField.AsObject;
-      case 'date':
-        return buildDateFilter(filterField, filter) as ResultFilterField.AsObject;
-      case 'status':
-        return buildStatusFilter(filterField, filter) as ResultFilterField.AsObject;
-      case 'number':
-        return buildNumberFilter(filterField, filter) as ResultFilterField.AsObject;
-      default: {
-        throw new Error(`Type ${type} not supported`);
-      }
       }
     };
+  }
+
+  createFilterField(field: ResultRawEnumField): FilterField {
+    return {
+      resultRawField: {
+        field: field as ResultRawEnumField
+      }
+    } satisfies ResultFilterField.AsObject['field'];
+  }
+
+  buildFilter(type: FilterType, filterField: FilterField, filter: Filter<ResultRawEnumField>) {
+    switch (type) {
+    case 'string':
+      return buildStringFilter(filterField, filter) as ResultFilterField.AsObject;
+    case 'date':
+      return buildDateFilter(filterField, filter) as ResultFilterField.AsObject;
+    case 'status':
+      return buildStatusFilter(filterField, filter) as ResultFilterField.AsObject;
+    case 'number':
+      return buildNumberFilter(filterField, filter) as ResultFilterField.AsObject;
+    default: {
+      throw new Error(`Type ${type} not supported`);
+    }
+    }
   }
 }

--- a/src/app/results/show.component.ts
+++ b/src/app/results/show.component.ts
@@ -1,3 +1,4 @@
+import { ResultRawEnumField } from '@aneoconsultingfr/armonik.api.angular';
 import { AfterViewInit, Component, OnInit, inject } from '@angular/core';
 import { MatIconModule } from '@angular/material/icon';
 import { MatSnackBar } from '@angular/material/snack-bar';
@@ -13,7 +14,7 @@ import { TableService } from '@services/table.service';
 import { UtilsService } from '@services/utils.service';
 import { ResultsFiltersService } from './services/results-filters.service';
 import { ResultsGrpcService } from './services/results-grpc.service';
-import { ResultsStatusesService } from './services/results-statuses.service';import { ResultRaw } from './types';
+import { ResultsStatusesService } from './services/results-statuses.service';import { ResultRaw, ResultRawFieldKey, ResultRawListOptions } from './types';
 
 
 @Component({
@@ -45,7 +46,7 @@ import { ResultsStatusesService } from './services/results-statuses.service';imp
     MatIconModule,
   ]
 })
-export class ShowComponent extends AppShowComponent<ResultRaw, ResultsGrpcService> implements OnInit, AfterViewInit, ShowActionInterface {
+export class ShowComponent extends AppShowComponent<ResultRaw, ResultRawFieldKey, ResultRawListOptions, ResultRawEnumField> implements OnInit, AfterViewInit, ShowActionInterface {
 
   protected override _grpcService = inject(ResultsGrpcService);
   private _resultsStatusesService = inject(ResultsStatusesService);

--- a/src/app/services/grpc-sort-field.service.spec.ts
+++ b/src/app/services/grpc-sort-field.service.spec.ts
@@ -1,10 +1,11 @@
-import { SessionField, SessionRawEnumField, TaskOptionEnumField } from '@aneoconsultingfr/armonik.api.angular';
+import { TaskOptionEnumField } from '@aneoconsultingfr/armonik.api.angular';
 import { SessionRawFieldKey } from '@app/sessions/types';
 import { TaskOptionsFieldKey } from '@app/tasks/types';
 import { GrpcSortFieldService } from './grpc-sort-field.service';
 
 describe('GrpcSortFieldService', () => {
   const service = new GrpcSortFieldService();
+  const mockFunction = jest.fn();
 
   it('should be created', () => {
     expect(service).toBeTruthy();
@@ -13,7 +14,7 @@ describe('GrpcSortFieldService', () => {
   describe('buildSortField', () => {
     it('should return taskOptionGenericField if data is sorted via a custom field', () => {
       const field = 'options.options.customField' as SessionRawFieldKey;
-      const result = service.buildSortField(field, () => {return {} as SessionField.AsObject;});
+      const result = service.buildSortField(field, mockFunction);
       expect(result).toEqual({
         taskOptionGenericField: {
           field: 'customField'
@@ -23,7 +24,7 @@ describe('GrpcSortFieldService', () => {
 
     it('should return taskOptionField if data is sorted via a task option field', () => {
       const field: TaskOptionsFieldKey = 'applicationName';
-      const result = service.buildSortField(field, () => {return {} as SessionField.AsObject;});
+      const result = service.buildSortField(field, mockFunction);
       expect(result).toEqual({
         taskOptionField: {
           field: TaskOptionEnumField.TASK_OPTION_ENUM_FIELD_APPLICATION_NAME
@@ -33,11 +34,14 @@ describe('GrpcSortFieldService', () => {
 
     it('should return the result of the buildField function if data is sorted via a basic field', () => {
       const field: SessionRawFieldKey = 'createdAt';
-      expect(service.buildSortField(field, () => {return {sessionRawField: {field: SessionRawEnumField.SESSION_RAW_ENUM_FIELD_SESSION_ID}};})).toEqual({
-        sessionRawField: {
-          field: SessionRawEnumField.SESSION_RAW_ENUM_FIELD_SESSION_ID
-        }
-      });
+      service.buildSortField(field, mockFunction);
+      expect(mockFunction).toHaveBeenCalled();
+    });
+
+    it('should handle null values', () => {
+      const field = null as unknown as SessionRawFieldKey;
+      service.buildSortField(field, mockFunction);
+      expect(mockFunction).toHaveBeenCalled();
     });
   });
 });

--- a/src/app/services/grpc-sort-field.service.spec.ts
+++ b/src/app/services/grpc-sort-field.service.spec.ts
@@ -1,16 +1,7 @@
-import { SessionField, SessionRawEnumField } from '@aneoconsultingfr/armonik.api.angular';
-import { SessionRaw } from '@app/sessions/types';
-import { TaskOptions } from '@app/tasks/types';
-import { ListOptionsSort } from '@app/types/options';
+import { SessionField, SessionRawEnumField, TaskOptionEnumField } from '@aneoconsultingfr/armonik.api.angular';
+import { SessionRawFieldKey } from '@app/sessions/types';
+import { TaskOptionsFieldKey } from '@app/tasks/types';
 import { GrpcSortFieldService } from './grpc-sort-field.service';
-
-function buildField(sortOptions: ListOptionsSort<SessionRaw & TaskOptions>): SessionField.AsObject {
-  return {
-    sessionRawField: {
-      field: sortOptions.active === 'sessionId' ? SessionRawEnumField.SESSION_RAW_ENUM_FIELD_SESSION_ID : SessionRawEnumField.SESSION_RAW_ENUM_FIELD_STATUS
-    }
-  };
-}
 
 describe('GrpcSortFieldService', () => {
   const service = new GrpcSortFieldService();
@@ -21,11 +12,8 @@ describe('GrpcSortFieldService', () => {
 
   describe('buildSortField', () => {
     it('should return taskOptionGenericField if data is sorted via a custom field', () => {
-      const sort = {
-        active: 'options.options.customField',
-        direction: 'asc'
-      } as unknown as ListOptionsSort<SessionRaw>;
-      const result = service.buildSortField<SessionRaw, SessionField.AsObject>(sort, () => {return {} as SessionField.AsObject;});
+      const field = 'options.options.customField' as SessionRawFieldKey;
+      const result = service.buildSortField(field, () => {return {} as SessionField.AsObject;});
       expect(result).toEqual({
         taskOptionGenericField: {
           field: 'customField'
@@ -34,24 +22,18 @@ describe('GrpcSortFieldService', () => {
     });
 
     it('should return taskOptionField if data is sorted via a task option field', () => {
-      const sort = {
-        active: 'options.applicationName',
-        direction: 'asc'
-      } as unknown as ListOptionsSort<SessionRaw>;
-      const result = service.buildSortField<SessionRaw, SessionField.AsObject>(sort, () => {return {} as SessionField.AsObject;});
+      const field: TaskOptionsFieldKey = 'applicationName';
+      const result = service.buildSortField(field, () => {return {} as SessionField.AsObject;});
       expect(result).toEqual({
         taskOptionField: {
-          field: 5
+          field: TaskOptionEnumField.TASK_OPTION_ENUM_FIELD_APPLICATION_NAME
         }
       });
     });
 
     it('should return the result of the buildField function if data is sorted via a basic field', () => {
-      const sort = {
-        active: 'sessionId',
-        direction: 'asc'
-      } as unknown as ListOptionsSort<SessionRaw>;
-      expect(service.buildSortField<SessionRaw, SessionField.AsObject>(sort, buildField)).toEqual({
+      const field: SessionRawFieldKey = 'createdAt';
+      expect(service.buildSortField(field, () => {return {sessionRawField: {field: SessionRawEnumField.SESSION_RAW_ENUM_FIELD_SESSION_ID}};})).toEqual({
         sessionRawField: {
           field: SessionRawEnumField.SESSION_RAW_ENUM_FIELD_SESSION_ID
         }

--- a/src/app/services/grpc-sort-field.service.ts
+++ b/src/app/services/grpc-sort-field.service.ts
@@ -28,10 +28,10 @@ export class GrpcSortFieldService {
           field: field.toString().replace('options.options.', '')
         }
       } as F;
-    } else if (this.sortOptionsFields[field as TaskOptionsFieldKey]) {
+    } else if (this.sortOptionsFields[field.replace('options.', '') as TaskOptionsFieldKey]) {
       return {
         taskOptionField: {
-          field: this.sortOptionsFields[field.toString().replace('options.', '') as TaskOptionsFieldKey]
+          field: this.sortOptionsFields[field.replace('options.', '') as TaskOptionsFieldKey]
         }
       } as F;
     } else {

--- a/src/app/services/grpc-sort-field.service.ts
+++ b/src/app/services/grpc-sort-field.service.ts
@@ -28,7 +28,7 @@ export class GrpcSortFieldService {
           field: field.toString().replace('options.options.', '')
         }
       } as F;
-    } else if (this.sortOptionsFields[field.replace('options.', '') as TaskOptionsFieldKey]) {
+    } else if (this.sortOptionsFields[field?.replace('options.', '') as TaskOptionsFieldKey]) {
       return {
         taskOptionField: {
           field: this.sortOptionsFields[field.replace('options.', '') as TaskOptionsFieldKey]

--- a/src/app/services/grpc-sort-field.service.ts
+++ b/src/app/services/grpc-sort-field.service.ts
@@ -21,13 +21,13 @@ export class GrpcSortFieldService {
     field: TaskSummaryEnumField | TaskOptionEnumField | SessionRawEnumField | SessionTaskOptionEnumField | undefined,
     buildField: () => F): F
   {
-    if (field && field.toString().startsWith('options.options.')) {
+    if (field?.toString().startsWith('options.options.')) {
       return {
         taskOptionGenericField: {
           field: field.toString().replace('options.options.', '')
         }
       } as F;
-    } else if (field && field.toString().startsWith('options.')) {
+    } else if (field?.toString().startsWith('options.')) {
       return {
         taskOptionField: {
           field: this.sortOptionsFields[field.toString().replace('options.', '') as TaskOptionsFieldKey]

--- a/src/app/services/grpc-sort-field.service.ts
+++ b/src/app/services/grpc-sort-field.service.ts
@@ -1,7 +1,5 @@
-import { SessionField, TaskField, TaskOptionEnumField } from '@aneoconsultingfr/armonik.api.angular';
-import { TaskOptions, TaskOptionsFieldKey } from '@app/tasks/types';
-import { DataRaw } from '../types/data';
-import { ListOptionsSort } from '../types/options';
+import { SessionField, SessionRawEnumField, SessionTaskOptionEnumField, TaskField, TaskOptionEnumField, TaskSummaryEnumField } from '@aneoconsultingfr/armonik.api.angular';
+import { TaskOptionsFieldKey } from '@app/tasks/types';
 
 export type GrpcSortOptionalFields = TaskField.AsObject | SessionField.AsObject;
 
@@ -19,24 +17,24 @@ export class GrpcSortFieldService {
     partitionId: TaskOptionEnumField.TASK_OPTION_ENUM_FIELD_PARTITION_ID,
   };
 
-  buildSortField<D extends DataRaw, F extends GrpcSortOptionalFields> (
-    sort: ListOptionsSort<D & TaskOptions>,
-    buildField: (sortOptions: ListOptionsSort<D & TaskOptions>) => F): F
+  buildSortField<F extends GrpcSortOptionalFields> (
+    field: TaskSummaryEnumField | TaskOptionEnumField | SessionRawEnumField | SessionTaskOptionEnumField | undefined,
+    buildField: () => F): F
   {
-    if (sort.active && sort.active.toString().startsWith('options.options.')) {
+    if (field && field.toString().startsWith('options.options.')) {
       return {
         taskOptionGenericField: {
-          field: sort.active.toString().replace('options.options.', '')
+          field: field.toString().replace('options.options.', '')
         }
       } as F;
-    } else if (sort.active && sort.active.toString().startsWith('options.')) {
+    } else if (field && field.toString().startsWith('options.')) {
       return {
         taskOptionField: {
-          field: this.sortOptionsFields[sort.active.toString().replace('options.', '') as TaskOptionsFieldKey]
+          field: this.sortOptionsFields[field.toString().replace('options.', '') as TaskOptionsFieldKey]
         }
       } as F;
     } else {
-      return buildField(sort);
+      return buildField();
     }
   }
 }

--- a/src/app/services/grpc-sort-field.service.ts
+++ b/src/app/services/grpc-sort-field.service.ts
@@ -1,5 +1,6 @@
-import { SessionField, SessionRawEnumField, SessionTaskOptionEnumField, TaskField, TaskOptionEnumField, TaskSummaryEnumField } from '@aneoconsultingfr/armonik.api.angular';
-import { TaskOptionsFieldKey } from '@app/tasks/types';
+import { SessionField, TaskField, TaskOptionEnumField } from '@aneoconsultingfr/armonik.api.angular';
+import { SessionRawFieldKey } from '@app/sessions/types';
+import { TaskOptionsFieldKey, TaskSummaryFieldKey } from '@app/tasks/types';
 
 export type GrpcSortOptionalFields = TaskField.AsObject | SessionField.AsObject;
 
@@ -18,7 +19,7 @@ export class GrpcSortFieldService {
   };
 
   buildSortField<F extends GrpcSortOptionalFields> (
-    field: TaskSummaryEnumField | TaskOptionEnumField | SessionRawEnumField | SessionTaskOptionEnumField | undefined,
+    field: SessionRawFieldKey | TaskSummaryFieldKey | TaskOptionsFieldKey,
     buildField: () => F): F
   {
     if (field?.toString().startsWith('options.options.')) {
@@ -27,7 +28,7 @@ export class GrpcSortFieldService {
           field: field.toString().replace('options.options.', '')
         }
       } as F;
-    } else if (field?.toString().startsWith('options.')) {
+    } else if (this.sortOptionsFields[field as TaskOptionsFieldKey]) {
       return {
         taskOptionField: {
           field: this.sortOptionsFields[field.toString().replace('options.', '') as TaskOptionsFieldKey]

--- a/src/app/services/utils.service.spec.ts
+++ b/src/app/services/utils.service.spec.ts
@@ -1,254 +1,57 @@
-import { FilterNumberOperator, FilterStatusOperator, FilterStringOperator, TaskOptionEnumField, TaskSummaryEnumField } from '@aneoconsultingfr/armonik.api.angular';
+import { FilterDateOperator, FilterStatusOperator, FilterStringOperator, TaskOptionEnumField, TaskStatus, TaskSummaryEnumField } from '@aneoconsultingfr/armonik.api.angular';
 import { TaskFilterDefinition } from '@app/tasks/types';
-import { Filter, FilterType, FiltersAnd, FiltersOr } from '@app/types/filters';
+import { Filter } from '@app/types/filters';
 import { UtilsService } from './utils.service';
 
 describe('UtilsService', () => {
   const service = new UtilsService<number, number>();
-  
-  const cb = (filter: Filter<number, number>) => {
-    return (type: FilterType, field: number | null | string, isForRoot: boolean, isCustom: boolean) => {
-      let filterField;
-      if (isForRoot) {
-        filterField = {
-          taskSummaryField: {
-            field: field as TaskSummaryEnumField
-          }
-        };
-      } else if (isCustom) {
-        filterField = {
-          taskOptionCustomField: {
-            field: field as unknown as string
-          }
-        };
-      } else {
-        filterField = {
-          taskOptionField: {
-            field: field as TaskOptionEnumField
-          }
-        };
-      }
-      return {
-        field: filterField,
-        filterString: {
-          value: filter.value?.toString() ?? '',
-          operator: filter.operator
-        }
-      };
-    };
-  };
+
+  const filterDefinitions: TaskFilterDefinition[] = [
+    {
+      type: 'status',
+      field: TaskSummaryEnumField.TASK_SUMMARY_ENUM_FIELD_STATUS,
+      for: 'root',
+      statuses: [
+        { key: 1, value: 'up' },
+        { key: '2', value: 'down'}
+      ]
+    },
+    {
+      type: 'string',
+      field: TaskSummaryEnumField.TASK_SUMMARY_ENUM_FIELD_TASK_ID,
+      for: 'root'
+    }
+  ];
 
   it('should create', () => {
     expect(service).toBeTruthy();
   });
 
-  describe('createFilters', () => {
-    const filtersAnd1: FiltersAnd<number, number> = [
-      {
-        field: TaskSummaryEnumField.TASK_SUMMARY_ENUM_FIELD_TASK_ID,
+  describe('recoverType', () => {
+    it('should recover filter type', () => {
+      const statusTypeFilter: Filter<TaskSummaryEnumField, TaskOptionEnumField> = {
+        field: TaskSummaryEnumField.TASK_SUMMARY_ENUM_FIELD_STATUS,
         for: 'root',
-        operator: FilterStringOperator.FILTER_STRING_OPERATOR_CONTAINS,
-        value: 'myFirstFilterValue'
-      },
-      {
-        field: TaskSummaryEnumField.TASK_SUMMARY_ENUM_FIELD_SESSION_ID,
-        for: 'root',
-        operator: FilterNumberOperator.FILTER_NUMBER_OPERATOR_EQUAL,
-        value: 1
-      },
-      {
-        field: 'options.options.FastCompute',
+        operator: FilterStatusOperator.FILTER_STATUS_OPERATOR_EQUAL,
+        value: TaskStatus.TASK_STATUS_COMPLETED
+      };
+      expect(service.recoverType(statusTypeFilter, filterDefinitions)).toEqual('status');
+    });
+
+    it('should recover a string type for a custom field filter', () => {
+      const customFilter: Filter<TaskSummaryEnumField, TaskOptionEnumField> = {
+        field: 'custom.FastCompute',
         for: 'custom',
-        operator: FilterStringOperator.FILTER_STRING_OPERATOR_NOT_CONTAINS,
-        value: 'true'
-      }
-    ];
-
-    const filtersAnd2: FiltersAnd<number, number> = [
-      {
-        field: TaskSummaryEnumField.TASK_SUMMARY_ENUM_FIELD_POD_TTL,
-        for: 'root',
-        operator: FilterNumberOperator.FILTER_NUMBER_OPERATOR_GREATER_THAN_OR_EQUAL,
-        value: 2
-      },
-      {
-        field: TaskOptionEnumField.TASK_OPTION_ENUM_FIELD_APPLICATION_NAME,
-        for: 'options',
-        operator: FilterStringOperator.FILTER_STRING_OPERATOR_CONTAINS,
+        operator: FilterStringOperator.FILTER_STRING_OPERATOR_ENDS_WITH,
         value: 'someValue'
-      }
-    ];
-
-    const filtersOr: FiltersOr<number, number> = [filtersAnd1, filtersAnd2];
-
-    const filterDefinitions: TaskFilterDefinition[] = [
-      {
-        for: 'root',
-        field: TaskSummaryEnumField.TASK_SUMMARY_ENUM_FIELD_SESSION_ID,
-        type: 'number'
-      },
-      {
-        for: 'root',
-        field: TaskSummaryEnumField.TASK_SUMMARY_ENUM_FIELD_TASK_ID,
-        type: 'string',
-      },
-      {
-        for: 'root',
-        field: TaskSummaryEnumField.TASK_SUMMARY_ENUM_FIELD_POD_HOSTNAME,
-        type: 'string'
-      },
-      {
-        for: 'root',
-        field: TaskSummaryEnumField.TASK_SUMMARY_ENUM_FIELD_POD_TTL,
-        type: 'number'
-      },
-      {
-        for: 'options',
-        field: TaskOptionEnumField.TASK_OPTION_ENUM_FIELD_APPLICATION_NAME,
-        type: 'string'
-      }
-    ];
-    const result = {
-      or: [{and:
-        [{
-          field: {
-            taskSummaryField: {
-              field: 16
-            }
-          },
-          filterString: {
-            value: 'myFirstFilterValue',
-            operator: 2
-          }
-        },
-        {
-          field: {
-            taskSummaryField: {
-              field: 1
-            }
-          },
-          filterString: {
-            value: '1',
-            operator: 0
-          }
-        },
-        {
-          field: {
-            taskOptionCustomField: {
-              field: 'options.options.FastCompute'
-            }
-          },
-          filterString: {
-            value: 'true',
-            operator: 3
-          }
-        }
-        ]
-      },
-      {and: 
-        [
-          {
-            field: {
-              taskSummaryField: {
-                field: 12
-              }
-            },
-            filterString: {
-              value: '2',
-              operator: 4
-            }
-          },
-          {
-            field: {
-              taskOptionField: {
-                field: 5
-              }
-            },
-            filterString: {
-              value: 'someValue',
-              operator: 2
-            }
-          }
-        ]
-      }]
-    };
-
-    it('Should create a FiltersOr with various filters', () => {
-      expect(service.createFilters(filtersOr, filterDefinitions, cb)).toEqual(result);
-    });
-
-    it('Should not put a filter with null attributes in the FiltersOr', () => {
-      const filtersAnd3: FiltersAnd<number, number> = [
-        {
-          field: null,
-          for: 'root',
-          operator: FilterNumberOperator.FILTER_NUMBER_OPERATOR_GREATER_THAN_OR_EQUAL,
-          value: 2
-        },
-        {
-          field: TaskSummaryEnumField.TASK_SUMMARY_ENUM_FIELD_PROCESSING_TO_END_DURATION,
-          for: 'root',
-          operator: null,
-          value: 2
-        },
-        {
-          field: TaskSummaryEnumField.TASK_SUMMARY_ENUM_FIELD_ACQUIRED_AT,
-          for: 'root',
-          operator: FilterNumberOperator.FILTER_NUMBER_OPERATOR_LESS_THAN_OR_EQUAL,
-          value: null
-        },
-      ];
-      filtersOr.push(filtersAnd3);
-      expect(service.createFilters(filtersOr, filterDefinitions, cb)).toEqual(result);
-    });
-
-    it('Should throw an error if its definitions are not in the filtersDefinition', () => {
-      const filtersAnd3: FiltersAnd<number, number> = [
-        {
-          field: TaskSummaryEnumField.TASK_SUMMARY_ENUM_FIELD_SESSION_ID,
-          for: 'options',
-          operator: FilterNumberOperator.FILTER_NUMBER_OPERATOR_LESS_THAN,
-          value: 42
-        }
-      ];
-      const filtersAnd4: FiltersAnd<number, number> = [
-        {
-          field: TaskSummaryEnumField.TASK_SUMMARY_ENUM_FIELD_STATUS,
-          for: 'root',
-          operator: FilterStatusOperator.FILTER_STATUS_OPERATOR_EQUAL,
-          value: 'someValue'
-        }
-      ];
-      filtersOr.push(filtersAnd3);
-      expect(() => {service.createFilters(filtersOr, filterDefinitions, cb);})
-        .toThrowError('Filter definition not found for field 1');
-      filtersOr.pop();
-      filtersOr.push(filtersAnd4);
-      expect(() => {service.createFilters(filtersOr, filterDefinitions, cb);})
-        .toThrowError('Filter definition not found for field 2');
+      };
+      expect(service.recoverType(customFilter, filterDefinitions)).toEqual('string');
     });
   });
 
-  describe('recoverStatuses', () => {
-    const filterDefinitions: TaskFilterDefinition[] = [
-      {
-        type: 'status',
-        field: TaskSummaryEnumField.TASK_SUMMARY_ENUM_FIELD_STATUS,
-        for: 'root',
-        statuses: [
-          { key: 1, value: 'up' },
-          { key: '2', value: 'down'}
-        ]
-      },
-      {
-        type: 'string',
-        field: TaskSummaryEnumField.TASK_SUMMARY_ENUM_FIELD_TASK_ID,
-        for: 'root'
-      }
-    ];
-    
+  describe('recoverStatuses', () => {    
     it('Should return statuses in case of a filterDefinition status', () => {
-      const correctStatusFilter: Filter<number, number> = {
+      const correctStatusFilter: Filter<TaskSummaryEnumField, TaskOptionEnumField> = {
         field: TaskSummaryEnumField.TASK_SUMMARY_ENUM_FIELD_STATUS,
         for: 'root',
         operator: FilterStatusOperator.FILTER_STATUS_OPERATOR_EQUAL,
@@ -262,14 +65,37 @@ describe('UtilsService', () => {
     });
     
     it('Should throw an error in case of a non-status filter', () => {
-      const incorrectStatusFilter: Filter<number, number> = {
+      const incorrectStatusFilter: Filter<TaskSummaryEnumField, TaskOptionEnumField> = {
         field: TaskSummaryEnumField.TASK_SUMMARY_ENUM_FIELD_TASK_ID,
         for: 'root',
         operator: FilterStringOperator.FILTER_STRING_OPERATOR_NOT_CONTAINS,
         value: 'someValue'
       };
       expect(() => {service.recoverStatuses(incorrectStatusFilter, filterDefinitions);})
-        .toThrowError('Filter definition is not a status');
+        .toThrow('Filter definition is not a status');
+    });
+  });
+
+  describe('recoverFilterDefinition', () => {
+    it('should recover the type definition of a filter', () => {
+      const correctStatusFilter: Filter<TaskSummaryEnumField, TaskOptionEnumField> = {
+        field: TaskSummaryEnumField.TASK_SUMMARY_ENUM_FIELD_STATUS,
+        for: 'root',
+        operator: FilterStatusOperator.FILTER_STATUS_OPERATOR_EQUAL,
+        value: 2
+      };
+      expect(service.recoverFilterDefinition(correctStatusFilter, filterDefinitions)).toEqual(filterDefinitions[0]);
+    });
+
+    it('should throw an error if there is no filter definition', () => {
+      const notExistingFilterType: Filter<TaskSummaryEnumField, TaskOptionEnumField> = {
+        field: TaskSummaryEnumField.TASK_SUMMARY_ENUM_FIELD_CREATED_AT,
+        for: 'root',
+        operator: FilterDateOperator.FILTER_DATE_OPERATOR_AFTER_OR_EQUAL,
+        value: '1133400883'
+      };
+      expect(() => service.recoverFilterDefinition(notExistingFilterType, filterDefinitions))
+        .toThrow(`Filter definition not found for field ${notExistingFilterType.field?.toString()}`);
     });
   });
 });

--- a/src/app/services/utils.service.ts
+++ b/src/app/services/utils.service.ts
@@ -1,136 +1,45 @@
 import { Injectable } from '@angular/core';
+import { FiltersEnums, FiltersOptionsEnums } from '@app/dashboard/types';
 import { FilterDefinition } from '@app/types/filter-definition';
-import { Filter, FilterType, FilterValueOptions, FiltersAnd, FiltersOr } from '@app/types/filters';
+import { Filter, FilterType, FilterValueOptions } from '@app/types/filters';
 
 @Injectable()
-// Need to generalize SessionRawEnumField
-export class UtilsService<T extends number, U extends number | null = null> {
-
-  createFilters<F>(filters: FiltersOr<T, U>, filtersDefinitions: FilterDefinition<T, U>[], cb: (filter: Filter<T, U>) => (type: FilterType, field: T | U | string | null, isForRoot: boolean, isCustom: boolean) => F) {
-    const or = this.#createFiltersOr<F>(filters, filtersDefinitions, cb);
-
-    return or;
-  }
-
-  /**
-   * Used to create a group of lines (OR).
-   */
-  #createFiltersOr<F>(filters: FiltersOr<T, U>, filtersDefinitions: FilterDefinition<T, U>[], cb: (filter: Filter<T, U>) => (type: FilterType, field: T | U | string | null, isForRoot: boolean, isCustom: boolean) => F) {
-    const filtersOr = [];
-
-    for (const filter of filters) {
-      const filtersAnd = this.#createFiltersAnd<F>(filter, filtersDefinitions, cb);
-
-      if (filtersAnd.and && filtersAnd.and.length > 0) {
-        filtersOr.push(filtersAnd);
-      }
-    }
-
-    return {
-      or: filtersOr
-    };
-  }
-
-  /**
-   * Used to create a line of filters (AND).
-   */
-  #createFiltersAnd<F>(filters: FiltersAnd<T, U>, filtersDefinitions: FilterDefinition<T, U>[], cb: (filter: Filter<T, U>) => (type: FilterType, field: T | U | string | null, isForRoot: boolean, isCustom: boolean) => F) {
-    const filtersAnd = [];
-
-    for (const filter of filters) {
-      const filterField = this.#createFilterField<F>(filter, filtersDefinitions, cb(filter));
-
-      if (filterField) {
-        filtersAnd.push(filterField);
-      }
-    }
-
-    return {
-      and: filtersAnd
-    };
-  }
-
-  /**
-   * Used to define a filter field.
-   */
-  #createFilterField<F>(filter: Filter<T, U>, filtersDefinitions: FilterDefinition<T, U>[], cb: (type: FilterType, field: T | U | string | null, isForRoot: boolean, isCustom: boolean) => F): F | null {
-    if (filter.field === null || filter.value === null || filter.operator === null) {
-      return null;
-    }
-
-    const type = this.recoverType(filter, filtersDefinitions);
-    const field = this.#recoverField(filter, filtersDefinitions);
-
-    return cb(type, field, this.#isForRoot(filter, filtersDefinitions), this.#isCustom(filter));
-  }
-
+export class UtilsService<F extends FiltersEnums, FO extends FiltersOptionsEnums | null = null> {
   /**
    * Recover the type of a filter definition using the filter.
    */
-  recoverType(filter: Filter<T, U>, filtersDefinitions: FilterDefinition<T, U>[]): FilterType  {
+  recoverType(filter: Filter<F, FO>, filtersDefinitions: FilterDefinition<F, FO>[]): FilterType {
     if (filter.for === 'custom') {
       return 'string';
     }
-    const filterDefinition = this.#recoverFilterDefinition(filter, filtersDefinitions);
-
+    const filterDefinition = this.recoverFilterDefinition(filter, filtersDefinitions);
+  
     return filterDefinition.type;
   }
-
+  
   /**
-   * Recover statuses of a filter definition using the filter.
-   */
-  recoverStatuses(filter: Filter<T, U>, filtersDefinitions: FilterDefinition<T, U>[]): FilterValueOptions {
-    const filterDefinition = this.#recoverFilterDefinition(filter, filtersDefinitions);
-
+     * Recover statuses of a filter definition using the filter.
+     */
+  recoverStatuses(filter: Filter<F, FO>, filtersDefinitions: FilterDefinition<F, FO>[]): FilterValueOptions {
+    const filterDefinition = this.recoverFilterDefinition(filter, filtersDefinitions);
+  
     if (filterDefinition.type !== 'status') {
       throw new Error('Filter definition is not a status');
     }
-
+  
     return filterDefinition.statuses;
   }
 
   /**
-   * Check if a filter is used for a root property of the table. 
-   * @param filter 
-   * @param filtersDefinitions 
-   * @returns true if root, false otherwise
-   */
-  #isForRoot(filter: Filter<T, U>, filtersDefinitions: FilterDefinition<T, U>[]): boolean {
-    return !this.#isCustom(filter) && this.#recoverFilterDefinition(filter, filtersDefinitions).for === 'root';
-  }
-
-  /**
-   * Check if a filter is used for a custom column of the table.
-   * @param filter
-   * @returns true if custom, false otherwise
-   */
-  #isCustom(filter: Filter<T, U>): boolean {
-    return filter.for === 'custom';
-  }
-
-  /**
-   * Recover the field of a filter definition using the filter.
-   */
-  #recoverField(filter: Filter<T, U>, filtersDefinitions: FilterDefinition<T, U>[]): T | U | string {
-    if(filter.for !== 'custom') {
-      const filterDefinition = this.#recoverFilterDefinition(filter, filtersDefinitions);
-      return filterDefinition.field;
-    } else {
-      return (filter.field as string);
-    }
-  }
-
-
-  /**
    * Recover the filter definition using the filter field.
    */
-  #recoverFilterDefinition(filter: Filter<T, U>, filtersDefinitions: FilterDefinition<T, U>[]): FilterDefinition<T, U> {
+  recoverFilterDefinition(filter: Filter<F, FO>, filtersDefinitions: FilterDefinition<F, FO>[]): FilterDefinition<F, FO> {
     const filterDefinition = filtersDefinitions.find(filterDefinition => filterDefinition.for === filter.for && filterDefinition.field === filter.field);
-
+  
     if (!filterDefinition) {
       throw new Error(`Filter definition not found for field ${filter.field?.toString()}`);
     }
-
+  
     return filterDefinition;
   }
 }

--- a/src/app/sessions/components/table.component.ts
+++ b/src/app/sessions/components/table.component.ts
@@ -1,4 +1,4 @@
-import { FilterDateOperator, FilterStringOperator, ListSessionsResponse, ResultRawEnumField, SessionRawEnumField, TaskOptionEnumField, TaskSummaryEnumField } from '@aneoconsultingfr/armonik.api.angular';
+import { FilterDateOperator, FilterStringOperator, ListSessionsResponse, ResultRawEnumField, SessionRawEnumField, SessionTaskOptionEnumField, TaskOptionEnumField, TaskSummaryEnumField } from '@aneoconsultingfr/armonik.api.angular';
 import { Clipboard} from '@angular/cdk/clipboard';
 import { AfterViewInit, Component, EventEmitter, Output, inject } from '@angular/core';
 import { MatDialog, MatDialogModule } from '@angular/material/dialog';
@@ -20,7 +20,7 @@ import { TableTasksByStatus, TasksByStatusService } from '@services/tasks-by-sta
 import { SessionsGrpcService } from '../services/sessions-grpc.service';
 import { SessionsIndexService } from '../services/sessions-index.service';
 import { SessionsStatusesService } from '../services/sessions-statuses.service';
-import { SessionRaw, SessionRawColumnKey, SessionRawFilters, SessionRawListOptions } from '../types';
+import { SessionRaw, SessionRawColumnKey, SessionRawFieldKey, SessionRawFilters, SessionRawListOptions } from '../types';
 
 @Component({
   selector: 'app-sessions-table',
@@ -42,7 +42,8 @@ import { SessionRaw, SessionRawColumnKey, SessionRawFilters, SessionRawListOptio
     MatDialogModule,
   ]
 })
-export class SessionsTableComponent extends AbstractTaskByStatusTableComponent<SessionRaw, SessionRawColumnKey, SessionRawListOptions, SessionRawFilters>  implements AfterViewInit, AbstractTableComponent<SessionRaw, SessionRawColumnKey, SessionRawListOptions, SessionRawFilters> {
+export class SessionsTableComponent extends AbstractTaskByStatusTableComponent<SessionRaw, SessionRawColumnKey, SessionRawFieldKey, SessionRawListOptions, SessionRawEnumField, SessionTaskOptionEnumField> 
+  implements AfterViewInit, AbstractTableComponent<SessionRaw, SessionRawColumnKey, SessionRawFieldKey, SessionRawListOptions, SessionRawEnumField, SessionTaskOptionEnumField> {
   @Output() cancelSession = new EventEmitter<string>();
   @Output() closeSession = new EventEmitter<string>();
   @Output() deleteSession = new EventEmitter<string>();

--- a/src/app/sessions/services/sessions-grpc.service.spec.ts
+++ b/src/app/sessions/services/sessions-grpc.service.spec.ts
@@ -127,6 +127,12 @@ describe('SessionsGrpcService', () => {
         field: SessionRawEnumField.SESSION_RAW_ENUM_FIELD_WORKER_SUBMISSION,
         operator: FilterBooleanOperator.FILTER_BOOLEAN_OPERATOR_IS,
         value: true
+      },
+      {
+        field: null,
+        for: 'root',
+        operator: FilterNumberOperator.FILTER_NUMBER_OPERATOR_LESS_THAN_OR_EQUAL,
+        value: 29
       }
     ]
   ];

--- a/src/app/sessions/services/sessions-grpc.service.ts
+++ b/src/app/sessions/services/sessions-grpc.service.ts
@@ -18,7 +18,6 @@ export class SessionsGrpcService extends GrpcTableService<SessionRawFieldKey, Se
   readonly tasksGrpcService = inject(TasksGrpcService);
   readonly sortFieldService = new GrpcSortFieldService();
 
-  readonly defaultSortField = SessionRawEnumField.SESSION_RAW_ENUM_FIELD_CREATED_AT;
   readonly sortFields: Record<SessionRawFieldKey, SessionRawEnumField> = {
     'sessionId': SessionRawEnumField.SESSION_RAW_ENUM_FIELD_SESSION_ID,
     'status': SessionRawEnumField.SESSION_RAW_ENUM_FIELD_STATUS,
@@ -39,13 +38,13 @@ export class SessionsGrpcService extends GrpcTableService<SessionRawFieldKey, Se
     return this.grpcClient.listSessions(listSessionsRequest);
   }
 
-  createSortField(field: SessionRawEnumField): ListDefaultSortField {
+  createSortField(field: SessionRawFieldKey): ListDefaultSortField {
     return {
       field: this.sortFieldService.buildSortField(field,
         () => {
           return {
             sessionRawField: {
-              field: field
+              field: this.sortFields[field] ?? SessionRawEnumField.SESSION_RAW_ENUM_FIELD_CREATED_AT
             }
           } as SessionField;
         }

--- a/src/app/sessions/show.component.ts
+++ b/src/app/sessions/show.component.ts
@@ -1,4 +1,4 @@
-import { FilterStringOperator, ResultRawEnumField, TaskSummaryEnumField } from '@aneoconsultingfr/armonik.api.angular';
+import { FilterStringOperator, ResultRawEnumField, SessionRawEnumField, SessionTaskOptionEnumField, TaskSummaryEnumField } from '@aneoconsultingfr/armonik.api.angular';
 import { AfterViewInit, Component, OnInit, inject } from '@angular/core';
 import { MatIconModule } from '@angular/material/icon';
 import { MatSnackBar } from '@angular/material/snack-bar';
@@ -23,7 +23,7 @@ import { SessionsFiltersService } from './services/sessions-filters.service';
 import { SessionsGrpcService } from './services/sessions-grpc.service';
 import { SessionsIndexService } from './services/sessions-index.service';
 import { SessionsStatusesService } from './services/sessions-statuses.service';
-import { SessionRaw } from './types';
+import { SessionRaw, SessionRawFieldKey, SessionRawListOptions } from './types';
 
 @Component({
   selector: 'app-sessions-show',
@@ -60,7 +60,9 @@ import { SessionRaw } from './types';
     MatIconModule,
   ]
 })
-export class ShowComponent extends AppShowComponent<SessionRaw, SessionsGrpcService> implements OnInit, AfterViewInit, ShowActionInterface, ShowCancellableInterface, ShowClosableInterface {
+export class ShowComponent extends AppShowComponent<SessionRaw, SessionRawFieldKey, SessionRawListOptions, SessionRawEnumField, SessionTaskOptionEnumField>
+  implements OnInit, AfterViewInit, ShowActionInterface, ShowCancellableInterface, ShowClosableInterface {
+
   cancel$ = new Subject<void>();
   pause$ = new Subject<void>();
   resume$ = new Subject<void>();

--- a/src/app/tasks/components/table.component.ts
+++ b/src/app/tasks/components/table.component.ts
@@ -14,7 +14,7 @@ import { GrpcSortFieldService } from '@services/grpc-sort-field.service';
 import { TasksGrpcService } from '../services/tasks-grpc.service';
 import { TasksIndexService } from '../services/tasks-index.service';
 import { TasksStatusesService } from '../services/tasks-statuses.service';
-import { TaskSummary, TaskSummaryColumnKey, TaskSummaryFilters, TaskSummaryListOptions } from '../types';
+import { TaskSummary, TaskSummaryColumnKey, TaskSummaryFieldKey, TaskSummaryListOptions } from '../types';
 
 @Component({
   selector: 'app-tasks-table',
@@ -31,7 +31,8 @@ import { TaskSummary, TaskSummaryColumnKey, TaskSummaryFilters, TaskSummaryListO
     TableComponent
   ]
 })
-export class TasksTableComponent extends AbstractTableComponent<TaskSummary, TaskSummaryColumnKey, TaskSummaryListOptions, TaskSummaryFilters> implements AfterViewInit {
+export class TasksTableComponent extends AbstractTableComponent<TaskSummary, TaskSummaryColumnKey, TaskSummaryFieldKey, TaskSummaryListOptions, TaskSummaryEnumField, TaskOptionEnumField>
+  implements AfterViewInit {
   @Input({ required: false }) set serviceIcon(entry: string | null) {
     if (entry) {
       this._serviceIcon = entry;

--- a/src/app/tasks/services/tasks-grpc.service.spec.ts
+++ b/src/app/tasks/services/tasks-grpc.service.spec.ts
@@ -87,6 +87,12 @@ describe('TasksGrpcService', () => {
         field: TaskSummaryEnumField.TASK_SUMMARY_ENUM_FIELD_CREATED_AT,
         operator: FilterDateOperator.FILTER_DATE_OPERATOR_AFTER_OR_EQUAL,
         value: '2313893210'
+      },
+      {
+        field: null,
+        for: 'root',
+        operator: FilterNumberOperator.FILTER_NUMBER_OPERATOR_LESS_THAN_OR_EQUAL,
+        value: 29
       }
     ]
   ];

--- a/src/app/tasks/services/tasks-grpc.service.ts
+++ b/src/app/tasks/services/tasks-grpc.service.ts
@@ -2,21 +2,20 @@ import { CancelTasksRequest, CancelTasksResponse, CountTasksByStatusRequest, Cou
 import { Injectable, inject } from '@angular/core';
 import { Observable } from 'rxjs';
 import { Filter, FilterType } from '@app/types/filters';
-import { ListOptionsSort } from '@app/types/options';
-import { GrpcCancelManyInterface, GrpcCountByStatusInterface, GrpcGetInterface, GrpcListInterface } from '@app/types/services/grpcService';
-import { buildDateFilter, buildNumberFilter, buildStatusFilter, buildStringFilter, sortDirections } from '@services/grpc-build-request.service';
+import { GrpcCancelManyInterface, GrpcCountByStatusInterface, GrpcGetInterface, GrpcTableService, ListDefaultSortField } from '@app/types/services/grpcService';
+import { FilterField, buildDateFilter, buildNumberFilter, buildStatusFilter, buildStringFilter } from '@services/grpc-build-request.service';
 import { GrpcSortFieldService } from '@services/grpc-sort-field.service';
-import { UtilsService } from '@services/utils.service';
 import { TasksFiltersService } from './tasks-filters.service';
-import { TaskOptions, TaskSummary, TaskSummaryField, TaskSummaryFieldKey, TaskSummaryFilters, TaskSummaryListOptions } from '../types';
+import { TaskSummaryFieldKey, TaskSummaryFilters, TaskSummaryListOptions } from '../types';
 
 @Injectable()
-export class TasksGrpcService implements GrpcListInterface<TasksClient, TaskSummaryListOptions, TaskSummaryFilters, TaskSummaryFieldKey, TaskSummaryEnumField, TaskOptionEnumField>, GrpcGetInterface<GetTaskResponse>, GrpcCancelManyInterface<CancelTasksResponse>, GrpcCountByStatusInterface<TaskSummaryFilters, TaskSummaryEnumField, TaskOptionEnumField> {
+export class TasksGrpcService extends GrpcTableService<TaskSummaryFieldKey, TaskSummaryListOptions, TaskSummaryEnumField, TaskOptionEnumField>
+  implements GrpcGetInterface<GetTaskResponse>, GrpcCancelManyInterface<CancelTasksResponse>, GrpcCountByStatusInterface<TaskSummaryFilters> {
   readonly filterService = inject(TasksFiltersService);
-  readonly utilsService = inject(UtilsService<TaskSummaryEnumField, TaskOptionEnumField>);
   readonly grpcClient = inject(TasksClient);
   readonly sortFieldService = inject(GrpcSortFieldService);
 
+  readonly defaultSortField = TaskSummaryEnumField.TASK_SUMMARY_ENUM_FIELD_CREATED_AT;
   readonly sortFields: Record<TaskSummaryFieldKey, TaskSummaryEnumField> = {
     id: TaskSummaryEnumField.TASK_SUMMARY_ENUM_FIELD_TASK_ID,
     sessionId: TaskSummaryEnumField.TASK_SUMMARY_ENUM_FIELD_SESSION_ID,
@@ -46,28 +45,7 @@ export class TasksGrpcService implements GrpcListInterface<TasksClient, TaskSumm
   };
 
   list$(options: TaskSummaryListOptions, filters: TaskSummaryFilters): Observable<ListTasksResponse> {
-
-    const requestFilters = this.utilsService.createFilters<TaskFilterField.AsObject>(filters, this.filterService.filtersDefinitions, this.#buildFilterField);
-    const sortField = this.sortFieldService.buildSortField(options.sort, 
-      (sort: ListOptionsSort<TaskSummary & TaskOptions>) => {
-        return {
-          taskSummaryField: {
-            field: this.sortFields[sort.active as TaskSummaryFieldKey] ?? TaskSummaryEnumField.TASK_SUMMARY_ENUM_FIELD_CREATED_AT
-          }
-        } as TaskField;
-      }
-    );
-
-    const listTasksRequest = new ListTasksRequest({
-      page: options.pageIndex,
-      pageSize: options.pageSize,
-      sort: {
-        direction: sortDirections[options.sort.direction],
-        field: sortField
-      },
-      filters: requestFilters
-    });
-
+    const listTasksRequest = new ListTasksRequest(this.createListRequest(options, filters) as ListTasksRequest);
     return this.grpcClient.listTasks(listTasksRequest);
   }
 
@@ -89,7 +67,7 @@ export class TasksGrpcService implements GrpcListInterface<TasksClient, TaskSumm
 
   countByStatus$(filters: TaskSummaryFilters): Observable<CountTasksByStatusResponse> {
 
-    const requestFilters = this.utilsService.createFilters<TaskFilterField.AsObject>(filters, this.filterService.filtersDefinitions, this.#buildFilterField);
+    const requestFilters = this.createFilters(filters, this.filterService.filtersDefinitions) as { or: { and: TaskFilterField.AsObject[] }[] };
 
     const request = new CountTasksByStatusRequest({
       filters: requestFilters
@@ -98,42 +76,54 @@ export class TasksGrpcService implements GrpcListInterface<TasksClient, TaskSumm
     return this.grpcClient.countTasksByStatus(request);
   }
 
-  #buildFilterField(filter: Filter<TaskSummaryEnumField, TaskOptionEnumField>) {
-    return (type: FilterType, field: TaskSummaryField, isForRoot: boolean, isCustom: boolean) => {
-
-      let filterField: TaskFilterField.AsObject['field'];
-      if (isForRoot) {
-        filterField = {
-          taskSummaryField: {
-            field: field as TaskSummaryEnumField
-          }
-        };
-      } else if (isCustom) {
-        filterField = {
-          taskOptionGenericField: {
-            field: field as string
-          }
-        };
-      } else {
-        filterField = {
-          taskOptionField: {
-            field: field as TaskOptionEnumField
-          }
-        };
-      }
-
-      switch (type) {
-      case 'string':
-        return buildStringFilter(filterField, filter) as TaskFilterField.AsObject;
-      case 'status':
-        return buildStatusFilter(filterField, filter) as TaskFilterField.AsObject;
-      case 'number':
-        return buildNumberFilter(filterField, filter) as TaskFilterField.AsObject;
-      case 'date':
-        return buildDateFilter(filterField, filter) as TaskFilterField.AsObject;
-      default:
-        throw new Error(`Type ${type} not supported`);
-      }
+  createSortField(field: TaskSummaryEnumField): ListDefaultSortField {
+    return {
+      field: this.sortFieldService.buildSortField(field,
+        () => {
+          return {
+            taskSummaryField: {
+              field: field
+            }
+          } as TaskField;
+        }
+      )
     };
+  }
+
+  createFilterField(field: TaskSummaryEnumField | TaskOptionEnumField | string, isForRoot?: boolean | undefined, isCustom?: boolean | undefined): FilterField {
+    if (isForRoot) {
+      return {
+        taskSummaryField: {
+          field: field as TaskSummaryEnumField
+        }
+      };
+    } else if (isCustom) {
+      return {
+        taskOptionGenericField: {
+          field: field as string
+        }
+      };
+    } else {
+      return {
+        taskOptionField: {
+          field: field as TaskOptionEnumField
+        }
+      };
+    }
+  }
+
+  buildFilter(type: FilterType, filterField: FilterField, filter: Filter<TaskSummaryEnumField, TaskOptionEnumField>): TaskFilterField.AsObject {
+    switch (type) {
+    case 'string':
+      return buildStringFilter(filterField, filter) as TaskFilterField.AsObject;
+    case 'status':
+      return buildStatusFilter(filterField, filter) as TaskFilterField.AsObject;
+    case 'number':
+      return buildNumberFilter(filterField, filter) as TaskFilterField.AsObject;
+    case 'date':
+      return buildDateFilter(filterField, filter) as TaskFilterField.AsObject;
+    default:
+      throw new Error(`Type ${type} not supported`);
+    }
   }
 }

--- a/src/app/tasks/services/tasks-grpc.service.ts
+++ b/src/app/tasks/services/tasks-grpc.service.ts
@@ -6,7 +6,7 @@ import { GrpcCancelManyInterface, GrpcCountByStatusInterface, GrpcGetInterface, 
 import { FilterField, buildDateFilter, buildNumberFilter, buildStatusFilter, buildStringFilter } from '@services/grpc-build-request.service';
 import { GrpcSortFieldService } from '@services/grpc-sort-field.service';
 import { TasksFiltersService } from './tasks-filters.service';
-import { TaskSummaryFieldKey, TaskSummaryFilters, TaskSummaryListOptions } from '../types';
+import { TaskOptionsFieldKey, TaskSummaryFieldKey, TaskSummaryFilters, TaskSummaryListOptions } from '../types';
 
 @Injectable()
 export class TasksGrpcService extends GrpcTableService<TaskSummaryFieldKey, TaskSummaryListOptions, TaskSummaryEnumField, TaskOptionEnumField>
@@ -15,7 +15,6 @@ export class TasksGrpcService extends GrpcTableService<TaskSummaryFieldKey, Task
   readonly grpcClient = inject(TasksClient);
   readonly sortFieldService = inject(GrpcSortFieldService);
 
-  readonly defaultSortField = TaskSummaryEnumField.TASK_SUMMARY_ENUM_FIELD_CREATED_AT;
   readonly sortFields: Record<TaskSummaryFieldKey, TaskSummaryEnumField> = {
     id: TaskSummaryEnumField.TASK_SUMMARY_ENUM_FIELD_TASK_ID,
     sessionId: TaskSummaryEnumField.TASK_SUMMARY_ENUM_FIELD_SESSION_ID,
@@ -76,13 +75,13 @@ export class TasksGrpcService extends GrpcTableService<TaskSummaryFieldKey, Task
     return this.grpcClient.countTasksByStatus(request);
   }
 
-  createSortField(field: TaskSummaryEnumField): ListDefaultSortField {
+  createSortField(field: TaskSummaryFieldKey | TaskOptionsFieldKey): ListDefaultSortField {
     return {
       field: this.sortFieldService.buildSortField(field,
         () => {
           return {
             taskSummaryField: {
-              field: field
+              field: this.sortFields[field as TaskSummaryFieldKey] ?? TaskSummaryEnumField.TASK_SUMMARY_ENUM_FIELD_CREATED_AT
             }
           } as TaskField;
         }

--- a/src/app/tasks/show.component.ts
+++ b/src/app/tasks/show.component.ts
@@ -1,4 +1,4 @@
-import { FilterStringOperator, ResultRawEnumField } from '@aneoconsultingfr/armonik.api.angular';
+import { FilterStringOperator, ResultRawEnumField, TaskOptionEnumField, TaskSummaryEnumField } from '@aneoconsultingfr/armonik.api.angular';
 import { AfterViewInit, Component, OnInit, inject } from '@angular/core';
 import { MatIconModule } from '@angular/material/icon';
 import { MatSnackBar } from '@angular/material/snack-bar';
@@ -18,7 +18,7 @@ import { UtilsService } from '@services/utils.service';
 import { TasksFiltersService } from './services/tasks-filters.service';
 import { TasksGrpcService } from './services/tasks-grpc.service';
 import { TasksStatusesService } from './services/tasks-statuses.service';
-import { TaskRaw } from './types';
+import { TaskRaw, TaskSummaryFieldKey, TaskSummaryListOptions } from './types';
 
 @Component({
   selector: 'app-tasks-show',
@@ -52,7 +52,7 @@ import { TaskRaw } from './types';
     MatIconModule,
   ]
 })
-export class ShowComponent extends AppShowComponent<TaskRaw, TasksGrpcService> implements OnInit, AfterViewInit, ShowCancellableInterface, ShowActionInterface {
+export class ShowComponent extends AppShowComponent<TaskRaw, TaskSummaryFieldKey, TaskSummaryListOptions, TaskSummaryEnumField, TaskOptionEnumField> implements OnInit, AfterViewInit, ShowCancellableInterface, ShowActionInterface {
 
   cancel$ = new Subject<void>();
 

--- a/src/app/types/components/show.ts
+++ b/src/app/types/components/show.ts
@@ -1,10 +1,12 @@
 import { inject } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { Subject, map, of } from 'rxjs';
+import { FiltersEnums, FiltersOptionsEnums } from '@app/dashboard/types';
 import { IconsService } from '@services/icons.service';
 import { NotificationService } from '@services/notification.service';
 import { ShareUrlService } from '@services/share-url.service';
-import { GrpcService } from '../services';
+import { IndexListOptions } from '../data';
+import { DataFieldKey, GrpcTableService } from '../services/grpcService';
 
 export type ShowActionButton = {
   id: string;
@@ -34,7 +36,7 @@ export interface ShowActionInterface {
   actionButtons: ShowActionButton[];
 }
 
-export abstract class AppShowComponent<T extends object, E extends GrpcService> {
+export abstract class AppShowComponent<T extends object, K extends DataFieldKey, O extends IndexListOptions, F extends FiltersEnums, FO extends FiltersOptionsEnums | null = null> {
   id: string;
   sharableURL: string = '';
   refresh = new Subject<void>();
@@ -42,7 +44,7 @@ export abstract class AppShowComponent<T extends object, E extends GrpcService> 
   data$: Subject<T> = new Subject<T>();
 
   private _iconsService = inject(IconsService);
-  protected _grpcService: E;
+  protected _grpcService: GrpcTableService<K, O, F, FO>;
   private _shareURLService = inject(ShareUrlService);
   private _notificationService = inject(NotificationService);
   private _route = inject(ActivatedRoute);

--- a/src/app/types/components/table.ts
+++ b/src/app/types/components/table.ts
@@ -2,20 +2,16 @@ import { SelectionModel } from '@angular/cdk/collections';
 import { Component, Input, OnInit, inject } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { Observable, Subject, catchError, map, of, switchMap } from 'rxjs';
-import { ApplicationRawFilters, ApplicationRawListOptions } from '@app/applications/types';
-import { ManageGroupsDialogData, ManageGroupsDialogResult, TasksStatusesGroup } from '@app/dashboard/types';
-import { PartitionRawFilters, PartitionRawListOptions } from '@app/partitions/types';
-import { ResultRawFilters, ResultRawListOptions } from '@app/results/types';
-import { SessionRawFilters, SessionRawListOptions } from '@app/sessions/types';
-import { TaskSummaryFilters, TaskSummaryListOptions } from '@app/tasks/types';
+import { FiltersEnums, FiltersOptionsEnums, ManageGroupsDialogData, ManageGroupsDialogResult, TasksStatusesGroup } from '@app/dashboard/types';
+import { TaskSummaryFilters } from '@app/tasks/types';
 import { ManageGroupsDialogComponent } from '@components/statuses/manage-groups-dialog.component';
 import { FiltersService } from '@services/filters.service';
 import { NotificationService } from '@services/notification.service';
 import { TableTasksByStatus, TasksByStatusService } from '@services/tasks-by-status.service';
 import { TableColumn } from '../column.type';
 import { ArmonikData, DataRaw, GrpcResponse, IndexListOptions, RawColumnKey } from '../data';
-import { RawFilters } from '../filters';
-import { GrpcService } from '../services';
+import { FiltersOr } from '../filters';
+import { DataFieldKey, GrpcTableService } from '../services/grpcService';
 import { IndexServiceInterface } from '../services/indexService';
 
 export interface SelectableTable<D extends DataRaw> {
@@ -26,7 +22,7 @@ export interface SelectableTable<D extends DataRaw> {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-export interface AbstractTableComponent<R extends DataRaw, C extends RawColumnKey, O extends IndexListOptions, F extends RawFilters> {
+export interface AbstractTableComponent<R extends DataRaw, C extends RawColumnKey, D extends DataFieldKey, O extends IndexListOptions, F extends FiltersEnums, FO extends FiltersOptionsEnums | null = null> {
   /**
    * Modify environment before fetching the data.
    * It is required for computing values that are not directly returned by the API (example: sessions durations).
@@ -47,32 +43,29 @@ export interface AbstractTableComponent<R extends DataRaw, C extends RawColumnKe
   template: '',
 })
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
-export abstract class AbstractTableComponent<R extends DataRaw, C extends RawColumnKey, O extends IndexListOptions, F extends RawFilters> {
+export abstract class AbstractTableComponent<R extends DataRaw, C extends RawColumnKey, D extends DataFieldKey, O extends IndexListOptions, F extends FiltersEnums, FO extends FiltersOptionsEnums | null = null> {
   @Input({ required: true }) displayedColumns: TableColumn<C>[] = [];
   @Input({ required: true }) options: O;
-  @Input({ required: true }) filters$: Subject<F>;
+  @Input({ required: true }) filters$: Subject<FiltersOr<F, FO>>;
   @Input({ required: true }) refresh$: Subject<void>;
   @Input({ required: true }) loading$: Subject<boolean>;
   @Input() lockColumns = false;
   
   data: ArmonikData<R>[] = [];
   total: number = 0;
-  filters: F = [] as unknown as F;
+  filters: FiltersOr<F, FO> = [] as FiltersOr<F, FO>;
 
   get columnKeys() {
     return this.displayedColumns.map(c => c.key);
   }
 
-  abstract readonly grpcService: GrpcService;
+  abstract readonly grpcService: GrpcTableService<D, O, F, FO>;
   abstract readonly indexService: IndexServiceInterface<C, O>;
   readonly filtersService = inject(FiltersService);
   readonly notificationService = inject(NotificationService);
 
-  list$(options: O, filters: F): Observable<GrpcResponse> {
-    return this.grpcService.list$(
-      options as TaskSummaryListOptions & SessionRawListOptions & ApplicationRawListOptions & ResultRawListOptions & PartitionRawListOptions,
-      filters as SessionRawFilters & TaskSummaryFilters & PartitionRawFilters & ApplicationRawFilters & ResultRawFilters
-    );
+  list$(options: O, filters: FiltersOr<F, FO>): Observable<GrpcResponse> {
+    return this.grpcService.list$(options, filters);
   }
 
   subscribeToData() {
@@ -150,7 +143,7 @@ export abstract class AbstractTableComponent<R extends DataRaw, C extends RawCol
   selector: 'app-results-table',
   template: '',
 })
-export abstract class AbstractTaskByStatusTableComponent<R extends DataRaw, C extends RawColumnKey, O extends IndexListOptions, F extends RawFilters> extends AbstractTableComponent<R, C, O, F> implements OnInit {
+export abstract class AbstractTaskByStatusTableComponent<R extends DataRaw, C extends RawColumnKey, D extends DataFieldKey, O extends IndexListOptions, F extends FiltersEnums, FO extends FiltersOptionsEnums | null = null> extends AbstractTableComponent<R, C, D, O, F, FO> implements OnInit {
   readonly tasksByStatusService = inject(TasksByStatusService);
   readonly dialog = inject(MatDialog);
 

--- a/src/app/types/services.ts
+++ b/src/app/types/services.ts
@@ -1,10 +1,5 @@
-import { ApplicationsGrpcService } from '@app/applications/services/applications-grpc.service';
-import { PartitionsGrpcService } from '@app/partitions/services/partitions-grpc.service';
-import { ResultsGrpcService } from '@app/results/services/results-grpc.service';
 import { ResultsStatusesService } from '@app/results/services/results-statuses.service';
-import { SessionsGrpcService } from '@app/sessions/services/sessions-grpc.service';
 import { SessionsStatusesService } from '@app/sessions/services/sessions-statuses.service';
-import { TasksGrpcService } from '@app/tasks/services/tasks-grpc.service';
 import { TasksStatusesService } from '@app/tasks/services/tasks-statuses.service';
 import { Status } from './data';
 
@@ -18,5 +13,3 @@ export interface CancelStatusesServiceI<S extends Status> extends StatusesServic
 }
 
 export type StatusesService = SessionsStatusesService | TasksStatusesService | ResultsStatusesService;
-
-export type GrpcService = TasksGrpcService | SessionsGrpcService | ApplicationsGrpcService | PartitionsGrpcService | ResultsGrpcService;

--- a/src/app/types/services/grpcService.ts
+++ b/src/app/types/services/grpcService.ts
@@ -1,4 +1,5 @@
-import { ApplicationsClient, CancelSessionResponse, CancelTasksResponse, CountTasksByStatusResponse, GetPartitionResponse, GetResultResponse, GetSessionResponse, GetTaskResponse, ListApplicationsResponse, ListPartitionsResponse, ListResultsResponse, ListSessionsResponse, ListTasksResponse, PartitionsClient, ResultsClient, SessionsClient, TasksClient } from '@aneoconsultingfr/armonik.api.angular';
+import { ApplicationFilterField, ApplicationsClient, CancelSessionResponse, CancelTasksResponse, CountTasksByStatusResponse, GetPartitionResponse, GetResultResponse, GetSessionResponse, GetTaskResponse, PartitionFilterField, PartitionsClient, ResultFilterField, ResultsClient, SessionFilterField, SessionsClient, TaskFilterField, TasksClient } from '@aneoconsultingfr/armonik.api.angular';
+import { inject } from '@angular/core';
 import { Observable } from 'rxjs';
 import { ApplicationRawFieldKey } from '@app/applications/types';
 import { FiltersEnums, FiltersOptionsEnums } from '@app/dashboard/types';
@@ -6,27 +7,29 @@ import { PartitionRawFieldKey } from '@app/partitions/types';
 import { ResultRawFieldKey } from '@app/results/types';
 import { SessionRawFieldKey } from '@app/sessions/types';
 import { TaskSummaryFieldKey } from '@app/tasks/types';
+import { FilterField, sortDirections } from '@services/grpc-build-request.service';
 import { UtilsService } from '@services/utils.service';
 import { FiltersServiceInterface } from './filtersService';
-import { IndexListFilters, IndexListOptions } from '../data';
-import { RawFilters } from '../filters';
+import { GrpcResponse, IndexListOptions } from '../data';
+import { FilterDefinition } from '../filter-definition';
+import { Filter, FilterType, FiltersAnd, FiltersOr, RawFilters } from '../filters';
 
 export type GrpcClient = TasksClient | ApplicationsClient | ResultsClient | SessionsClient | PartitionsClient;
-export type ListResponse = ListTasksResponse | ListApplicationsResponse | ListResultsResponse | ListSessionsResponse | ListPartitionsResponse;
 export type GetResponse = GetTaskResponse | GetPartitionResponse | GetResultResponse | GetSessionResponse;
 export type CancelResponse = CancelSessionResponse | CancelTasksResponse;
 export type CountByStatusResponse = CountTasksByStatusResponse;
 export type DataFieldKey = SessionRawFieldKey | TaskSummaryFieldKey | ApplicationRawFieldKey | PartitionRawFieldKey | ResultRawFieldKey;
+export type RequestFilterField = TaskFilterField.AsObject | SessionFilterField.AsObject | PartitionFilterField.AsObject | ApplicationFilterField.AsObject | ResultFilterField.AsObject;
 
-export interface GrpcListInterface<C extends GrpcClient, L extends IndexListOptions, E extends IndexListFilters, K extends DataFieldKey, F extends FiltersEnums, O extends FiltersOptionsEnums | null = null> {
-  readonly filterService: FiltersServiceInterface<RawFilters, F>; 
-  readonly utilsService: UtilsService<F, O>;
-  readonly grpcClient: C;
+export type ListDefaultSortField = {
+  field: object
+};
 
-  readonly sortFields: Record<K, F>;
+export type ListApplicationSortField = {
+  fields: object[]
+};
 
-  list$(options: L, filters: E): Observable<ListResponse>;
-}
+export type ListRequestSortField = ListApplicationSortField | ListDefaultSortField;
 
 export interface GrpcGetInterface<R extends GetResponse> {
   readonly grpcClient: GrpcClient;
@@ -43,10 +46,153 @@ export interface GrpcCancelManyInterface<R extends CancelResponse> {
   cancel$(ids: string[]): Observable<R>;
 }
 
-export interface GrpcCountByStatusInterface<R extends RawFilters, F extends FiltersEnums, O extends FiltersOptionsEnums | null = null> {
-  readonly utilsService: UtilsService<F, O>;
+export interface GrpcCountByStatusInterface<R extends RawFilters> {
   readonly grpcClient: GrpcClient;
-
   countByStatus$(filters: R): Observable<CountByStatusResponse>;
+}
+
+export abstract class GrpcTableService<K extends DataFieldKey, O extends IndexListOptions, F extends FiltersEnums, FO extends FiltersOptionsEnums | null = null> {
+  abstract readonly sortFields: Record<K, F>;
+  abstract readonly defaultSortField: F;
+  
+  abstract readonly grpcClient: GrpcClient;
+  abstract readonly filterService: FiltersServiceInterface<RawFilters, F>;
+
+  readonly utilsService = inject(UtilsService<F, FO>);
+  
+  /**
+   * Required function to list data for a table. You want to create a ListRequest object with the `createListRequest` function.
+   * 
+   * Example:
+   * ```ts
+   * list$(options: TaskSummaryListOptions, filters: TaskSummaryFilters): Observable<ListTasksResponse> {
+   *   const listTasksRequest = new ListTasksRequest(this.createListRequest(options, filters));
+   * 
+   *   return this.grpcClient.listTasks(listTasksRequest);
+   * }
+   * ```
+   */
+  abstract list$(options: O, filters: FiltersOr<F, FO>): Observable<GrpcResponse>;
+
+  /**
+   * The sort field can be either an option, custom or basic enum field.
+   * Since the parent class cannot make the difference between two enum field (for example taskSummaryField and sessionRawField), you have to implement it yourself.
+   */
+  abstract createSortField(field: F): ListRequestSortField;
+
+  /**
+   * The filter field can be either an option, custom or basic enum field.
+   * Since the parent class cannot make the difference between two enum field (for example taskSummaryField and sessionRawField), you have to implement it yourself.
+   */
+  abstract createFilterField(field: F | FO | string, isForRoot?: boolean, isCustom?: boolean): FilterField;
+
+  /**
+   * Transform a GUI filter into a gRPC ArmoniK filter. Needed for listing requests.
+   */
+  abstract buildFilter(type: FilterType, filterField: FilterField, filter: Filter<F, FO>): RequestFilterField;
+
+  /**
+   * Creates the gRPC list request needed to list the required data.
+   * Will transform filters before making the request. 
+   */
+  createListRequest(options: O, filters: FiltersOr<F, FO>) {
+    const requestFilter = this.createFilters(filters, this.filterService.filtersDefinitions as FilterDefinition<F, FO>[]);
+    const sortField = this.createSortField(this.sortFields[options.sort.active as K] ?? this.defaultSortField);
+    console.log(sortField);
+
+    return {
+      page: options.pageIndex,
+      pageSize: options.pageSize,
+      sort: {
+        direction: sortDirections[options.sort.direction],
+        ...sortField,
+      },
+      filters: requestFilter
+    };
+  }
+
+  /**
+   * Used to create a group of lines (OR).
+   */
+  createFilters(filters: FiltersOr<F, FO>, filtersDefinitions: FilterDefinition<F, FO>[]) {
+    const filtersOr = [];
+
+    for (const filter of filters) {
+      const filtersAnd = this.createFiltersAnd(filter, filtersDefinitions);
+
+      if (filtersAnd.and && filtersAnd.and.length > 0) {
+        filtersOr.push(filtersAnd);
+      }
+    }
+
+    return {
+      or: filtersOr
+    };
+  }
+
+  /**
+   * Used to create a line of filters (AND).
+   */
+  private createFiltersAnd(filters: FiltersAnd<F, FO>, filtersDefinitions: FilterDefinition<F, FO>[]) {
+    const filtersAnd = [];
+
+    for (const filter of filters) {
+      const filterField = this.createFilterObject(filter, filtersDefinitions);
+
+      if (filterField) {
+        filtersAnd.push(filterField);
+      }
+    }
+
+    return {
+      and: filtersAnd
+    };
+  }
+
+  /**
+   * Used to define a filter field.
+   */
+  private createFilterObject(filter: Filter<F, FO>, filtersDefinitions: FilterDefinition<F, FO>[]) {
+    if (filter.field === null || filter.value === null || filter.operator === null) {
+      return null;
+    }
+
+    const type = this.utilsService.recoverType(filter, filtersDefinitions);
+    const field = this.recoverField(filter, filtersDefinitions);
+    const filterField = this.createFilterField(field, this.isForRoot(filter, filtersDefinitions), this.isCustom(filter));
+
+    return this.buildFilter(type, filterField, filter);
+  }
+
+  /**
+   * Check if a filter is used for a root property of the table. 
+   * @param filter 
+   * @param filtersDefinitions 
+   * @returns true if root, false otherwise
+   */
+  private isForRoot(filter: Filter<F, FO>, filtersDefinitions: FilterDefinition<F, FO>[]): boolean {
+    return !this.isCustom(filter) && this.utilsService.recoverFilterDefinition(filter, filtersDefinitions).for === 'root';
+  }
+
+  /**
+   * Check if a filter is used for a custom column of the table.
+   * @param filter
+   * @returns true if custom, false otherwise
+   */
+  private isCustom(filter: Filter<F, FO>): boolean {
+    return filter.for === 'custom';
+  }
+
+  /**
+   * Recover the field of a filter definition using the filter.
+   */
+  private recoverField(filter: Filter<F, FO>, filtersDefinitions: FilterDefinition<F, FO>[]): F | FO | string {
+    if(filter.for !== 'custom') {
+      const filterDefinition = this.utilsService.recoverFilterDefinition(filter, filtersDefinitions);
+      return filterDefinition.field;
+    } else {
+      return (filter.field as string);
+    }
+  }
 }
 

--- a/src/app/types/services/grpcService.ts
+++ b/src/app/types/services/grpcService.ts
@@ -53,7 +53,6 @@ export interface GrpcCountByStatusInterface<R extends RawFilters> {
 
 export abstract class GrpcTableService<K extends DataFieldKey, O extends IndexListOptions, F extends FiltersEnums, FO extends FiltersOptionsEnums | null = null> {
   abstract readonly sortFields: Record<K, F>;
-  abstract readonly defaultSortField: F;
   
   abstract readonly grpcClient: GrpcClient;
   abstract readonly filterService: FiltersServiceInterface<RawFilters, F>;
@@ -78,7 +77,7 @@ export abstract class GrpcTableService<K extends DataFieldKey, O extends IndexLi
    * The sort field can be either an option, custom or basic enum field.
    * Since the parent class cannot make the difference between two enum field (for example taskSummaryField and sessionRawField), you have to implement it yourself.
    */
-  abstract createSortField(field: F): ListRequestSortField;
+  abstract createSortField(field: K): ListRequestSortField;
 
   /**
    * The filter field can be either an option, custom or basic enum field.
@@ -97,8 +96,7 @@ export abstract class GrpcTableService<K extends DataFieldKey, O extends IndexLi
    */
   createListRequest(options: O, filters: FiltersOr<F, FO>) {
     const requestFilter = this.createFilters(filters, this.filterService.filtersDefinitions as FilterDefinition<F, FO>[]);
-    const sortField = this.createSortField(this.sortFields[options.sort.active as K] ?? this.defaultSortField);
-    console.log(sortField);
+    const sortField = this.createSortField(options.sort.active as K);
 
     return {
       page: options.pageIndex,


### PR DESCRIPTION
The GrpcTableClass is an abstraction of the grpc services that list data for tables. It gives a simple way to referenciate it, and allows a developper to only build few functions and let the abstraction do the rest.

A lot of code had to be edited in order to make it compatible.