### PR TITLE
refactor: show card content display

### DIFF
--- a/src/app/components/show-card-content.component.html
+++ b/src/app/components/show-card-content.component.html
@@ -1,44 +1,52 @@
-@if (!isArray(data) && keys.length > 0) {
-  @for(key of keys; track key) {  
-    @if (!isArray(data[key]) && !isObject(key)) {
-      <p>
-        <!-- Key -->
-        <span class="key">{{ pretty(key) }}: </span>
-        <!-- Value -->
-        @if (isStatus(key)) {  
-          <span>{{ statusToLabel(key) | emptyCell }}</span>
-        } @else if (isString(key) || isNumber(key)) {
-          <span>{{ data[key] | emptyCell }}</span>
-        } @else if (isTimestamp(key)) {
-          <span>{{ toDate(key) | date: 'yyyy-MM-dd &nbsp;HH:mm:ss' | emptyCell}}</span>
-        } @else if (isDuration(key)) {
-          <span >{{ toDuration(key) | duration | emptyCell }}</span>
-        } @else {
-          <span>-</span>
-        }
-      </p>
-    } @else if (isArray(data[key])) {
-      <!-- Array -->
-      <span class="key">{{ pretty(key) }}:</span>
-      <ul class="array-list">
-        @for (item of findArray(key); track $index) {
-          <li>{{ item }}</li>
-        }
-      </ul>
-    } @else {
-      <!-- Object -->
-      <span class="key">{{ pretty(key) }}:</span>
-      <app-show-card-content [data]="findObject(key)" [statuses]="statuses"/>
+<section>
+  @if (!isArray(data) && keys.length > 0) {
+    @for(key of keys; track key) {  
+      @if (!isArray(data[key]) && !isObject(key)) {
+        <p>
+          <!-- Key -->
+          <span class="key">{{ pretty(key) }}: </span>
+          <!-- Value -->
+          <mat-chip>
+            @if (isStatus(key)) {  
+              <span>{{ statusToLabel(key) | emptyCell }}</span>
+            } @else if (isString(key) || isNumber(key)) {
+              <span>{{ data[key] | emptyCell }}</span>
+            } @else if (isTimestamp(key)) {
+              <span>{{ toDate(key) | date: 'yyyy-MM-dd &nbsp;HH:mm:ss' | emptyCell}}</span>
+            } @else if (isDuration(key)) {
+              <span >{{ toDuration(key) | duration | emptyCell }}</span>
+            } @else {
+              <span>-</span>
+            }
+          </mat-chip>
+        </p>
+      } @else if (isArray(data[key])) {
+        <!-- Array -->
+        <article>
+          <span class="key">{{ pretty(key) }}:</span>
+          <ul class="array-list">
+            @for (item of findArray(key); track $index) {
+              <li>{{ item }}</li>
+            }
+          </ul>
+        </article>
+      } @else {
+        <!-- Object -->
+        <article>
+          <span class="key">{{ pretty(key) }}:</span>
+          <app-show-card-content [data]="findObject(key)" [statuses]="statuses"/>
+        </article>
+      }
     }
+  } @else if (isArray(data) && hasLength(data)) {
+    <ul class="array-list">
+      @for (item of toArray(data); track $index) {
+        <li>{{ item }}</li>
+      }
+    </ul>
+  } @else {
+    <p class="no-data">
+      <em>No data</em>
+    </p>
   }
-} @else if (isArray(data) && hasLength(data)) {
-  <ul class="array-list">
-    @for (item of toArray(data); track $index) {
-      <li>{{ item }}</li>
-    }
-  </ul>
-} @else {
-  <p>
-    <em>No data</em>
-  </p>
-}
+</section>

--- a/src/app/components/show-card-content.component.spec.ts
+++ b/src/app/components/show-card-content.component.spec.ts
@@ -51,6 +51,27 @@ describe('ShowCardContentComponent', () => {
     expect(component).toBeTruthy();
   });
 
+  describe('initialisation', () => {
+    it('should have set data', () => {
+      expect(component.data).toEqual(data);
+    });
+
+    it('should not erase data if a null value is passed', () => {
+      component.data = null;
+      expect(component.data).toEqual(data);
+    });
+
+    it('should set every keys of data', () => {
+      expect(component.keys).toEqual(Object.keys(data).toSorted((a: string, b: string) => a.toLowerCase().localeCompare(b.toLowerCase())));
+    });
+
+    it('should set wanted keys', () => {
+      const keys = ['array', 'duration', 'empty', 'emptyArray', 'number'];
+      component.keys = keys;
+      expect(component.keys).toEqual(keys);
+    });
+  });
+
   describe('isString', () => {
     it('Should return true when a string is provided', () => {
       expect(component.isString('string')).toBeTruthy();
@@ -359,7 +380,7 @@ describe('ShowCardContentComponent', () => {
     });
 
     it('should return undefined if there is no data', () => {
-      component.data = undefined as unknown as SandBox;
+      component['_data'] = undefined as unknown as Data;
       expect(component.toDate('time')).toBeUndefined();
     });
   });
@@ -370,7 +391,7 @@ describe('ShowCardContentComponent', () => {
     });
 
     it('should return null if the data is undefined', () => {
-      component.data = undefined as unknown as SandBox;
+      component['_data'] = undefined as unknown as Data;
       expect(component.toDuration('duration')).toBeNull();
     });
   });

--- a/src/app/components/show-card-content.component.ts
+++ b/src/app/components/show-card-content.component.ts
@@ -1,5 +1,6 @@
 import { DatePipe } from '@angular/common';
 import { Component, Input } from '@angular/core';
+import { MatChipsModule } from '@angular/material/chips';
 import { Duration, Timestamp } from '@ngx-grpc/well-known-types';
 import { DurationPipe } from '@pipes/duration.pipe';
 import { EmptyCellPipe } from '@pipes/empty-cell.pipe';
@@ -12,39 +13,85 @@ type Data = {
   selector: 'app-show-card-content',
   templateUrl: './show-card-content.component.html',
   styles: [`
-app-show-card-content {
-  display: block;
-  margin-left: 1rem;
+section {
+  margin: 1rem;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0.5rem;
+}
 
+section > * {
+  margin-bottom: 1rem;
+}
+
+article {
+  grid-column: 1 / 4;
+  display: flex;
+  flex-direction: column;
+}
+
+app-show-card-content {
   border-left: 1px solid #eee;
   padding-left: 1rem;
+  margin-left: 1rem;
+}
+
+p {
+  width: fit-content;
+}
+
+.no-data {
+  grid-column: 1 / 4;
+  width: 100%;
+  text-align: center;
 }
 
 .array-list {
   margin: 0;
+}
+
+.key {
+  font-weight: bold;
 }
   `],
   imports: [
     DurationPipe,
     DatePipe,
     EmptyCellPipe,
+    MatChipsModule,
   ],
   standalone: true
 })
 export class ShowCardContentComponent<T extends object> {
   @Input({ required: true }) set data(entry: T | T[] | null) {
-    this._data = entry as Data;
     if (entry) {
-      this.keys = Object.keys(this.data).sort((a, b) => a.toString().localeCompare(b.toString()));
+      this._data = entry as Data;
+      if (this._keys.length === 0) {
+        this.setDefaultKeys();
+      }
     }
   }
   @Input({ required: true }) statuses: Record<number, string> = [];
 
-  keys: (keyof Data)[] = [];
-  private _data: Data;
+  @Input({ required: false }) set keys(entries: (keyof Data)[]) {
+    if (entries.length !== 0) {
+      this._keys = entries;
+    }
+  }
+
+  private _keys: (keyof Data)[] = [];
+  private _data: Data = {};
 
   get data(): Data {
     return this._data;
+  }
+
+  get keys(): (keyof Data)[] {
+    return this._keys;
+  }
+
+  setDefaultKeys() {
+    this._keys = Object.keys(this.data).sort((a, b) => a.toString().localeCompare(b.toString()));
   }
 
   /**


### PR DESCRIPTION
Now, data is display in a grid composed of 3 columns:
![image](https://github.com/aneoconsulting/ArmoniK.Admin.GUI/assets/117363666/719adb58-964b-40c8-b9a3-2722a9709d45)

Developpers also have the posibility to display only the data they want:
![image](https://github.com/aneoconsulting/ArmoniK.Admin.GUI/assets/117363666/a545432d-bac0-40ae-8d43-862b27ac8059)
