### PR TITLE
fix: linear increase of count by status refresh

### DIFF
--- a/src/app/components/count-tasks-by-status.component.spec.ts
+++ b/src/app/components/count-tasks-by-status.component.spec.ts
@@ -55,19 +55,25 @@ describe('CountTasksByStatusComponent', () => {
     component.refresh = refresh$;
     component.filters = filters;
     component.statusesGroups = statusesGroups;
+    component.ngOnInit();
   });
 
   it('Should run', () => {
     expect(component).toBeTruthy();
   });
 
-  describe('initCount', () => {
+  describe('initialisation', () => {
+    it('should subscribe to refresh', () => {
+      expect(refresh$.observed).toBeTruthy();
+    });
+
     it('should set id', () => {
       expect(component.id).toEqual(filters[0][0].value);
     });
 
     it('should not set id if there is no filter value', () => {
-      component.initCount([]);
+      component.filters = [];
+      component.initId();
       expect(component.id).toEqual(undefined);
     });
   });
@@ -83,24 +89,20 @@ describe('CountTasksByStatusComponent', () => {
   });
 
   describe('setting filters', () => {
-    it('should subscribe to refresh', () => {
-      expect(refresh$.observed).toBeTruthy();
-    });
-
-    it('should refresh counts', () => {
-      expect(refreshSpy).toHaveBeenCalled();
+    it('should set filters', () => {
+      expect(component.filters).toEqual(filters);
     });
   });
 
   describe('Refreshing', () => {
     it('should update statusesCounts', () => {
-      component.refresh.next();
+      refresh$.next();
       expect(component.statusesCount()).toEqual(finalStatusesCount);
     });
 
     it('should set null if there is no response status', () => {
       mockTasksGrpcService.countByStatus$.mockReturnValue(of({ status: undefined }));
-      component.refresh.next();
+      refresh$.next();
       expect(component.statusesCount()).toEqual([]);
     });
   });

--- a/src/app/components/count-tasks-by-status.component.ts
+++ b/src/app/components/count-tasks-by-status.component.ts
@@ -64,10 +64,10 @@ export class CountTasksByStatusComponent implements OnInit {
   }
 
   ngOnInit(): void {
-    this.initCount();
+    this.initId();
   }
 
-  initCount() {
+  initId() {
     this.#setId(this.filters);
   }
 

--- a/src/app/components/count-tasks-by-status.component.ts
+++ b/src/app/components/count-tasks-by-status.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input, OnInit, WritableSignal, inject, signal } from '@angular/core';
-import { Subject, Subscription, switchMap } from 'rxjs';
+import { Subject, switchMap } from 'rxjs';
 import { TasksStatusesGroup } from '@app/dashboard/types';
 import { TasksFiltersService } from '@app/tasks/services/tasks-filters.service';
 import { TasksGrpcService } from '@app/tasks/services/tasks-grpc.service';
@@ -29,7 +29,18 @@ import { ViewTasksByStatusComponent } from '@components/view-tasks-by-status.com
   ]
 })
 export class CountTasksByStatusComponent implements OnInit {
+  private readonly tasksGrpcService = inject(TasksGrpcService);
+
+  id: string | undefined;
+  statusesCount: WritableSignal<StatusCount[]> = signal([]);
+  loading = true;
+
+  private _statusesGroups: TasksStatusesGroup[] = [];
+  private _filters: TaskSummaryFilters;
+  private _refresh$: Subject<void>;
+
   @Input({ required: true }) queryParams: Record<string, string> = {};
+
   @Input({ required: true }) set refresh(subject: Subject<void>) {
     this._refresh$ = subject;
     this.initRefresh();
@@ -37,15 +48,8 @@ export class CountTasksByStatusComponent implements OnInit {
 
   @Input({ required: true }) set statusesGroups(entries: TasksStatusesGroup[]) {
     this._statusesGroups = entries;
-    if (this.refresh) {
-      this._refresh$.next();
-    }
+    this._refresh$.next();
   }
-
-  id: string | undefined;
-  private _statusesGroups: TasksStatusesGroup[] = [];
-  private _filters: TaskSummaryFilters;
-  private _refresh$: Subject<void>;
 
   get statusesGroups(): TasksStatusesGroup[] {
     return this._statusesGroups;
@@ -55,17 +59,8 @@ export class CountTasksByStatusComponent implements OnInit {
     return this._filters;
   }
 
-  statusesCount: WritableSignal<StatusCount[]> = signal([]);
-
-  loading = true;
-
-  private readonly tasksGrpcService = inject(TasksGrpcService);
-
-  subscription = new Subscription();
-
   @Input({ required: true }) set filters(entries: TaskSummaryFilters) {
     this._filters = entries;
-    this._refresh$.next();
   }
 
   ngOnInit(): void {

--- a/src/app/components/table/table-cell.component.html
+++ b/src/app/components/table/table-cell.component.html
@@ -19,9 +19,9 @@
   @case ('count') {
     <app-count-tasks-by-status
       [refresh]="refreshStatuses"
+      [filters]="countFilters"
       [statusesGroups]="statusesGroups"
       [queryParams]="queryTasksParams"
-      [filters]="countFilters"
     />
   }
   @case ('select') {


### PR DESCRIPTION
The component use a `refresh` subject that is "piped" to fetch the data.

Before, it was initiated when a `TaskSummaryFilter` was passed to the component. But since the filters are updated every time we get new data, the initialisation was remade, adding a new fetch instruction to the already existing one.