### PR TITLE
feat: tasks by status auto name

### DIFF
--- a/src/app/components/statuses/form-statuses-group.component.html
+++ b/src/app/components/statuses/form-statuses-group.component.html
@@ -1,35 +1,35 @@
 <form [formGroup]="groupForm" (ngSubmit)="onSubmit()">
-    <mat-dialog-content>
-  
-      <mat-form-field subscriptSizing="dynamic" appearance="outline">
-        <mat-label for="name" i18n="Name of the statuses group"> Name </mat-label>
-        <input matInput id="name" type="text" formControlName="name" i18n-placeholder="Placeholder" placeholder="Name of your group" required i18n="Input error">
-        @if (groupForm.get('name')?.hasError('required')) {
-          <mat-error i18n="Error message">
-            Name is <strong>required</strong>
-          </mat-error>
+  <mat-dialog-content>
+
+    <mat-form-field subscriptSizing="dynamic" appearance="outline">
+      <mat-label for="name" i18n="Name of the statuses group"> Name </mat-label>
+      <input matInput id="name" type="text" formControlName="name" i18n-placeholder placeholder="Name of your group" required i18n="Input error">
+      @if (groupForm.get('name')?.hasError('required')) {
+        <mat-error i18n="Error message">
+          Name is <strong>required</strong>
+        </mat-error>
+      }
+    </mat-form-field>
+
+    <mat-form-field subscriptSizing="dynamic" appearance="outline">
+      <mat-label for="color" i18n="Color of the statuses group"> Color </mat-label>
+      <input matInput id="color" type="color" formControlName="color" i18n-placeholder placeholder="color of your group">
+    </mat-form-field>
+
+    <div class="statuses">
+      <h3 i18n> Statuses </h3>
+      <div class="inputs">
+        @for (status of statuses; track status.value) {
+          <mat-checkbox [value]="status.value" (change)="onCheckboxChange($event)" [checked]="isChecked(status)">
+            {{ status.name }}
+          </mat-checkbox>
         }
-      </mat-form-field>
-  
-      <mat-form-field subscriptSizing="dynamic" appearance="outline">
-        <mat-label for="color" i18n="Color of the statuses group"> Color </mat-label>
-        <input matInput id="color" type="color" formControlName="color" i18n-placeholder="Placeholder" placeholder="color of your group">
-      </mat-form-field>
-  
-      <div class="statuses">
-        <h3 i18n> Statuses </h3>
-        <div class="inputs">
-          @for (status of statuses; track status.value) {
-            <mat-checkbox [value]="status.value" (change)="onCheckboxChange($event)" [checked]="isChecked(status)">
-              {{ status.name }}
-            </mat-checkbox>
-          }
-        </div>
       </div>
-    </mat-dialog-content>
-  
-    <mat-dialog-actions align="end">
-      <button mat-button (click)="onCancel()" type="button" i18n="Dialog action"> Cancel </button>
-      <button mat-flat-button type="submit" color="primary" [disabled]="!groupForm.valid" i18n="Dialog action"> Confirm </button>
-    </mat-dialog-actions>
-  </form>
+    </div>
+  </mat-dialog-content>
+
+  <mat-dialog-actions align="end">
+    <button mat-button (click)="onCancel()" type="button" i18n="Dialog action"> Cancel </button>
+    <button mat-flat-button type="submit" color="primary" [disabled]="!groupForm.valid" i18n="Dialog action"> Confirm </button>
+  </mat-dialog-actions>
+</form>

--- a/src/app/components/statuses/manage-groups-dialog.component.spec.ts
+++ b/src/app/components/statuses/manage-groups-dialog.component.spec.ts
@@ -49,7 +49,6 @@ describe('ManageGroupsDialogComponent', () => {
         }}
       ]
     }).inject(ManageGroupsDialogComponent);
-    component.ngOnInit();
   });
 
   it('should run', () => {


### PR DESCRIPTION
When creating a new group of tasks status for sessions, partitions and applications, selecting the first status will give its name to the group.

Also refactored the group creation form.