### PR TITLE
chore(ux): messages display in inspection page

### DIFF
--- a/src/app/components/inspection/inspection-object.component.html
+++ b/src/app/components/inspection/inspection-object.component.html
@@ -10,6 +10,10 @@
             <app-inspection-object [data]="getObject(field)" />
           </mat-expansion-panel>
         </mat-accordion>
+      } @else if (field.type === 'output') {
+        <app-message [message]="getError(field)" [label]="field.key" />
+      } @else if(field.type === 'message') {
+        <app-message [message]="getMessage(field)" [label]="field.key" />
       } @else {
         <app-field-content [field]="field" [statuses]="statuses" [data]="data" />
       }

--- a/src/app/components/inspection/inspection-object.component.spec.ts
+++ b/src/app/components/inspection/inspection-object.component.spec.ts
@@ -1,7 +1,12 @@
 import { TaskStatus } from '@aneoconsultingfr/armonik.api.angular';
 import { TaskRaw } from '@app/tasks/types';
 import { Field } from '@app/types/column.type';
+import { DataRaw } from '@app/types/data';
 import { InspectionObjectComponent } from './inspection-object.component';
+
+function findField<T extends DataRaw>(key: string, fields: Field<T>[]) {
+  return fields.find(field => field.key === key);
+}
 
 describe('InspectionObjectComponent', () => {
   const component = new InspectionObjectComponent<TaskRaw, TaskStatus>();
@@ -10,6 +15,11 @@ describe('InspectionObjectComponent', () => {
     id: 'taskId',
     options: {
       applicationName: 'string',
+    },
+    statusMessage: 'some message',
+    output: {
+      error: 'error message',
+      success: false,
     }
   } as TaskRaw;
 
@@ -25,13 +35,17 @@ describe('InspectionObjectComponent', () => {
       link: 'sessions'
     },
     {
+      key: 'output',
+      type: 'output'
+    },
+    {
+      key: 'statusMessage',
+      type: 'message'
+    },
+    {
       key: 'options',
       type: 'object'
     },
-    {
-      key: 'createdAt',
-      type: 'date'
-    }
   ];
 
   const statuses: Record<TaskStatus, string> = {
@@ -65,11 +79,19 @@ describe('InspectionObjectComponent', () => {
     it('should set data keys as fields if none are provided', () => {
       component.fields = [];
       component.data = data;
-      expect(component.fields).toEqual([{ key: 'id' }, { key: 'options' }]);
+      expect(component.fields).toEqual([{ key: 'id' }, { key: 'options' }, { key: 'output' }, { key: 'statusMessage' }]);
     });
   });
 
   it('should get an object', () => {
-    expect(component.getObject(fields[2])).toEqual(data.options);
+    expect(component.getObject(findField('options', fields)!)).toEqual(data.options);
+  });
+
+  it('should get the output error', () => {
+    expect(component.getError(findField('output', fields)!)).toEqual(data.output?.error);
+  });
+
+  it('should get the message', () => {
+    expect(component.getMessage(findField('statusMessage', fields)!)).toEqual(data.statusMessage);
   });
 });

--- a/src/app/components/inspection/inspection-object.component.ts
+++ b/src/app/components/inspection/inspection-object.component.ts
@@ -2,9 +2,10 @@ import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
 import { MatExpansionModule } from '@angular/material/expansion';
 import { TaskOptions } from '@app/tasks/types';
 import { Field } from '@app/types/column.type';
-import { DataRaw, Status } from '@app/types/data';
+import { DataRaw, Status, TaskOutput } from '@app/types/data';
 import { PrettyPipe } from '@pipes/pretty.pipe';
 import { FieldContentComponent } from './field-content.component';
+import { MessageComponent } from './message.component';
 
 @Component({
   selector: 'app-inspection-object',
@@ -14,6 +15,7 @@ import { FieldContentComponent } from './field-content.component';
     MatExpansionModule,
     PrettyPipe,
     FieldContentComponent,
+    MessageComponent
   ],
   styleUrl: '../../../inspections.css',
   changeDetection: ChangeDetectionStrategy.OnPush
@@ -48,6 +50,14 @@ export class InspectionObjectComponent<T extends DataRaw, S extends Status, O ex
 
   get fields() {
     return this._fields;
+  }
+
+  getError(field: Field<T> | Field<O>): string {
+    return ((this.data as T)[field.key as keyof T] as TaskOutput).error;
+  }
+
+  getMessage(field: Field<T> | Field<O>): string {
+    return (this.data as T)[field.key as keyof T] as string;
   }
 
   getObject(field: Field<T> | Field<O>): T {

--- a/src/app/components/inspection/message.component.css
+++ b/src/app/components/inspection/message.component.css
@@ -1,0 +1,13 @@
+mat-card {
+  padding: 1rem;
+}
+
+#message-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+h2 {
+  margin: 0px;
+}

--- a/src/app/components/inspection/message.component.html
+++ b/src/app/components/inspection/message.component.html
@@ -1,0 +1,9 @@
+@if (message) {
+  <section id="message-header">
+    <h2 i18n>{{ label | pretty }}</h2>
+    <button mat-icon-button (click)="copy()">
+      <mat-icon [fontIcon]="copyIcon" />
+    </button>
+  </section>
+  <mat-card appearance="outlined">{{ message }}</mat-card>
+}

--- a/src/app/components/inspection/message.component.spec.ts
+++ b/src/app/components/inspection/message.component.spec.ts
@@ -1,0 +1,58 @@
+import { Clipboard } from '@angular/cdk/clipboard';
+import { TestBed } from '@angular/core/testing';
+import { NotificationService } from '@services/notification.service';
+import { MessageComponent } from './message.component';
+
+describe('MessageComponent', () => {
+  let component: MessageComponent;
+
+  const label = 'Output';
+  const error = 'Error message';
+
+  const mockNotificationService = {
+    success: jest.fn(),
+  };
+
+  const mockClipboard = {
+    copy: jest.fn()
+  };
+
+  beforeEach(() => {
+    component = TestBed.configureTestingModule({
+      providers: [
+        MessageComponent,
+        { provide: NotificationService, useValue: mockNotificationService },
+        { provide: Clipboard, useValue: mockClipboard },
+      ]
+    }).inject(MessageComponent);
+
+    component.label = label;
+    component.message = error;
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should set label', () => {
+    expect(component.label).toEqual(label);
+  });
+
+  it('should set the message', () => {
+    expect(component.message).toEqual(error);
+  });
+
+  describe('copy', () => {
+    beforeEach(() => {
+      component.copy();
+    });
+    
+    it('should copy the message', () => {
+      expect(mockClipboard.copy).toHaveBeenCalledWith(error);
+    });
+
+    it('should notify the user', () => {
+      expect(mockNotificationService.success).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/app/components/inspection/message.component.ts
+++ b/src/app/components/inspection/message.component.ts
@@ -1,0 +1,47 @@
+import { Clipboard } from '@angular/cdk/clipboard';
+import { Component, Input, inject } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
+import { MatIconModule } from '@angular/material/icon';
+import { PrettyPipe } from '@pipes/pretty.pipe';
+import { NotificationService } from '@services/notification.service';
+
+@Component({
+  selector: 'app-message',
+  templateUrl: 'message.component.html',
+  styleUrl: 'message.component.css',
+  standalone: true,
+  imports: [
+    MatCardModule,
+    MatButtonModule,
+    MatIconModule,
+    PrettyPipe,
+  ]
+})
+export class MessageComponent {
+  @Input({ required: true }) message: string | undefined;
+
+  @Input({ required: false }) set label(entry: string | number | symbol | undefined) {
+    if (entry) {
+      this._label = entry.toString();
+    }
+  }
+
+  private _label = $localize`Message`;
+
+  get label(): string {
+    return this._label;
+  }
+
+  readonly copyIcon = 'content_copy';
+
+  private readonly clipboard = inject(Clipboard);
+  private readonly notificationService = inject(NotificationService);
+
+  copy() {
+    if (this.message) {
+      this.clipboard.copy(this.message);
+      this.notificationService.success('Message copied');
+    }
+  }
+}

--- a/src/app/results/services/results-inspection.service.ts
+++ b/src/app/results/services/results-inspection.service.ts
@@ -21,6 +21,7 @@ export class ResultsInspectionService extends InspectionService<ResultRaw> {
     },
     {
       key: 'createdBy',
+      link: 'task',
     },
     {
       key: 'completedAt',

--- a/src/app/tasks/services/tasks-inspection.service.ts
+++ b/src/app/tasks/services/tasks-inspection.service.ts
@@ -71,11 +71,11 @@ export class TasksInspectionService extends InspectionService<TaskRaw> {
     },
     {
       key: 'statusMessage',
-      type: 'object'
+      type: 'message'
     },
     {
       key: 'output',
-      type: 'object'
+      type: 'output'
     },
   ];
 

--- a/src/app/types/column.type.ts
+++ b/src/app/types/column.type.ts
@@ -1,7 +1,7 @@
 import { TaskOptions } from '@app/tasks/types';
 import { ColumnKey, DataRaw } from '@app/types/data';
 
-export type DataType = 'raw' | 'link' | 'object' | 'date' | 'duration' | 'status' | 'array'; 
+export type DataType = 'raw' | 'link' | 'object' | 'date' | 'duration' | 'status' | 'array' | 'output' | 'message'; 
 export type ColumnType = DataType | 'count' | 'actions' | 'select';
 
 export type Field<T extends DataRaw | TaskOptions | null> = {

--- a/src/app/types/data.ts
+++ b/src/app/types/data.ts
@@ -46,3 +46,8 @@ export interface ResultData extends ArmonikData<ResultRaw> {
 export type Status = TaskStatus | SessionStatus | ResultStatus;
 
 export type GrpcResponse = ListApplicationsResponse | ListTasksResponse | ListSessionsResponse | ListPartitionsResponse | ListResultsResponse;
+
+export type TaskOutput = {
+  error: string;
+  success: boolean;
+}

--- a/src/inspections.css
+++ b/src/inspections.css
@@ -33,7 +33,7 @@
   row-gap: 0.5rem;
 }
 
-mat-accordion {
+mat-accordion, app-message {
   grid-column: 1 / 4;
 }
 


### PR DESCRIPTION
New behaviour: the messages objects, such as `Output` and `Status Message`, inside a `TaskRaw` object, will be displayed only if their message is not empty.

The display will be as follow:
![image](https://github.com/user-attachments/assets/481bae03-daf6-46f4-a9ad-b5dacedb3d5d)
