### PR TITLE
fix: add selectionChange event binding to tasks table

### DIFF
--- a/src/app/components/table/table.component.ts
+++ b/src/app/components/table/table.component.ts
@@ -46,7 +46,8 @@ export class TableComponent<T extends DataRaw, S extends Status, O extends TaskO
       const selection = entries.filter(entry => this.isSelected(entry.raw)).map(entry => entry.raw);
       this.selection.clear();
       this.selection.select(...selection);
-      this._isAllSelected = this.selection.selected.length === entries.length;
+      this._isAllSelected = this.selection.selected.length === entries.length && entries.length > 0;
+      this.emitSelectionChange();
     }
   }
 


### PR DESCRIPTION
# Fix: Cancel Tasks button remains disabled when selecting tasks

## Problem
The "Cancel Tasks" button stayed disabled even when tasks were selected in the tasks table.

