### PR TITLE
fix: selectchange for canceltask

### DIFF
--- a/src/app/tasks/index.component.html
+++ b/src/app/tasks/index.component.html
@@ -64,5 +64,6 @@
   [urlTemplate]="urlTemplate"
   (retries)="onRetries($event)"
   (optionsUpdate)="onOptionsChange()"
+  (selectionChange)="onSelectionChange($event)"
 />
   


### PR DESCRIPTION
The last fix for cancelling a task wasn't working properly. A missing onSelectChange was added in order for the button cancel tasks to be clickable 