### PR TITLE
feat: actions and select behaviour

### DIFF
--- a/src/app/components/table/table.component.html
+++ b/src/app/components/table/table.component.html
@@ -5,7 +5,7 @@
     aria-label="Data Table">
 
     @for (column of columns; track column.key) {
-    <ng-container [matColumnDef]="column.key.toString()" [sticky]="column.type === 'select'">
+    <ng-container [matColumnDef]="column.key.toString()" [sticky]="stickLeftColumns.includes(column.type ?? 'raw')" [stickyEnd]="stickRightColumns.includes(column.type ?? 'raw')">
       <!-- Header -->
       <th mat-header-cell mat-sort-header [disabled]="!column.sortable" *matHeaderCellDef cdkDrag appNoWrap>
         <app-table-column-header [column]="column" [checked]="selection.hasValue() && isAllSelected"

--- a/src/app/components/table/table.component.spec.ts
+++ b/src/app/components/table/table.component.spec.ts
@@ -69,18 +69,6 @@ describe('TableComponent', () => {
 
   const total = 1;
 
-  const sort: MatSort = {
-    active: 'namespace',
-    direction: 'asc',
-    sortChange: new EventEmitter()
-  } as unknown as MatSort;
-
-  const paginator: MatPaginator = {
-    pageIndex: 2,
-    pageSize: 50,
-    page: new EventEmitter()
-  } as unknown as MatPaginator;
-
   const sessionComparator = (a: SessionRaw, b: SessionRaw) => {
     return a.sessionId === b.sessionId;
   };
@@ -104,8 +92,16 @@ describe('TableComponent', () => {
         { provide: DefaultConfigService, useValue: mockDefaultConfigService },
       ],
     }).inject(TableComponent<SessionRaw, SessionStatus, TaskOptions>);
-    component.sort = sort;
-    component.paginator = paginator;
+    component.sort = {
+      active: 'namespace',
+      direction: 'asc',
+      sortChange: new EventEmitter()
+    } as unknown as MatSort;
+    component.paginator = {
+      pageIndex: 2,
+      pageSize: 50,
+      page: new EventEmitter()
+    } as unknown as MatPaginator;
     component.columns = structuredClone(columns);
     component.dataComparator = sessionComparator;
     component.data = data;
@@ -113,6 +109,10 @@ describe('TableComponent', () => {
     component.options = options;
     component.selection.clear();
     component.ngAfterViewInit();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
   });
 
   it('should create', () => {
@@ -125,7 +125,7 @@ describe('TableComponent', () => {
 
   describe('init', () => {
     it('should call the storage service', () => {
-      expect(mockStorageService.getItem).toHaveBeenCalledWith('table-columns-behaviour');
+      expect(mockStorageService.getItem).toHaveBeenCalledWith('table-columns-behaviour', true);
     });
 
     it('should set the columnsBehaviour record', () => {
@@ -139,12 +139,23 @@ describe('TableComponent', () => {
     it('should set the stickRightColumn', () => {
       expect(component.stickRightColumns).toEqual(['actions']);
     });
+
+    it('should set "isAllSelected" to false if the data length is different than the selection length', () => {
+      expect(component.isAllSelected).toBeFalsy();
+    });
+    
+    it('should set "isAllSelected" to true if the data length is equal to the selection length', () => {
+      component.selection.clear();
+      component.selection.selected.push(...data.map(d => d.raw));
+      component.data = data;
+      expect(component.isAllSelected).toBeTruthy();
+    });
   });
 
   describe('sortChange', () => {
     it('should change sort', () => {
-      sort.active = 'status';
-      sort.direction = 'desc';
+      component.sort.active = 'status';
+      component.sort.direction = 'desc';
       component.sort.sortChange.emit();
       expect(component.options).toEqual({
         pageIndex: 0,
@@ -165,15 +176,15 @@ describe('TableComponent', () => {
 
   describe('paginator', () => {
     it('should change pageIndex', () => {
-      paginator.pageIndex = 3;
-      paginator.pageSize = 25;
+      component.paginator.pageIndex = 3;
+      component.paginator.pageSize = 25;
       component.paginator.page.emit();
       expect(component.options).toEqual({
         pageIndex: 3,
         pageSize: 25,
         sort: {
-          active: 'status',
-          direction: 'desc',
+          active: 'namespace',
+          direction: 'asc',
         }
       });
     });
@@ -185,7 +196,7 @@ describe('TableComponent', () => {
     });
 
     it('should slice data if pageSize is lower', () => {
-      paginator.pageSize = 1;
+      component.paginator.pageSize = 1;
       component.paginator.page.emit();
       expect(component.data).toEqual([data[0]]);
     });
@@ -206,7 +217,7 @@ describe('TableComponent', () => {
     });
 
     it('should emit columnDrop', () => {
-      expect(spy).toHaveBeenCalledWith(['select', 'sessionId', 'count', 'actions']);
+      expect(spy).toHaveBeenCalledWith(['select', 'count', 'sessionId', 'actions']);
     });
 
     it('should change columns order', () => {
@@ -217,14 +228,14 @@ describe('TableComponent', () => {
           sortable: false,
         },
         {
-          key: 'sessionId',
-          name: 'Session ID',
-          sortable: true,
-        },
-        {
           key: 'count',
           name: 'count',
           sortable: false,
+        },
+        {
+          key: 'sessionId',
+          name: 'Session ID',
+          sortable: true,
         },
         {
           key: 'actions',
@@ -266,7 +277,7 @@ describe('TableComponent', () => {
 
     it('should clear all row', () => {
       const spy = jest.spyOn(component.selection, 'clear');
-      component.selection.selected.push(...data.map(d => d.raw));
+      component['_isAllSelected'] = true;
       component.toggleAllRows();
       expect(spy).toHaveBeenCalled();
     });

--- a/src/app/components/table/table.component.spec.ts
+++ b/src/app/components/table/table.component.spec.ts
@@ -1,17 +1,20 @@
 import { SessionStatus } from '@aneoconsultingfr/armonik.api.angular';
 import { CdkDragDrop } from '@angular/cdk/drag-drop';
 import { EventEmitter } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatSort } from '@angular/material/sort';
 import { SessionRaw } from '@app/sessions/types';
 import { TaskOptions } from '@app/tasks/types';
-import { TableColumn } from '@app/types/column.type';
+import { ColumnsBehaviourValues, TableColumn } from '@app/types/column.type';
 import { SessionData } from '@app/types/data';
 import { ListOptions } from '@app/types/options';
+import { DefaultConfigService } from '@services/default-config.service';
+import { StorageService } from '@services/storage.service';
 import { TableComponent } from './table.component';
 
 describe('TableComponent', () => {
-  const component = new TableComponent<SessionRaw, SessionStatus, TaskOptions>();
+  let component: TableComponent<SessionRaw, SessionStatus, TaskOptions>;
 
   const columns: TableColumn<SessionRaw, TaskOptions>[] = [
     {
@@ -82,14 +85,32 @@ describe('TableComponent', () => {
     return a.sessionId === b.sessionId;
   };
 
+  const mockStorageService = {
+    getItem: jest.fn(),
+  };
+  
+  const mockDefaultConfigService = {
+    defaultTableColumnsBehaviour: {
+      'select': ColumnsBehaviourValues.LEFT,
+      'actions': ColumnsBehaviourValues.RIGHT,
+    } as Record<string, ColumnsBehaviourValues>,
+  };
+  
   beforeEach(() => {
+    component = TestBed.configureTestingModule({
+      providers: [
+        TableComponent,
+        { provide: StorageService, useValue: mockStorageService },
+        { provide: DefaultConfigService, useValue: mockDefaultConfigService },
+      ],
+    }).inject(TableComponent<SessionRaw, SessionStatus, TaskOptions>);
+    component.sort = sort;
+    component.paginator = paginator;
     component.columns = structuredClone(columns);
     component.dataComparator = sessionComparator;
     component.data = data;
     component.total = total;
     component.options = options;
-    component.sort = sort;
-    component.paginator = paginator;
     component.selection.clear();
     component.ngAfterViewInit();
   });
@@ -99,7 +120,25 @@ describe('TableComponent', () => {
   });
 
   it('should set columnsKeys', () => {
-    expect(component.columnsKeys).toEqual(['select', 'sessionId', 'actions', 'count']);
+    expect(component.columnsKeys).toEqual(['select', 'sessionId', 'count', 'actions']);
+  });
+
+  describe('init', () => {
+    it('should call the storage service', () => {
+      expect(mockStorageService.getItem).toHaveBeenCalledWith('table-columns-behaviour');
+    });
+
+    it('should set the columnsBehaviour record', () => {
+      expect(component['columnsBehaviour']).toEqual(mockDefaultConfigService.defaultTableColumnsBehaviour);
+    });
+
+    it('should set the stickLeftColumn', () => {
+      expect(component.stickLeftColumns).toEqual(['select']);
+    });
+
+    it('should set the stickRightColumn', () => {
+      expect(component.stickRightColumns).toEqual(['actions']);
+    });
   });
 
   describe('sortChange', () => {
@@ -167,7 +206,7 @@ describe('TableComponent', () => {
     });
 
     it('should emit columnDrop', () => {
-      expect(spy).toHaveBeenCalledWith(['select', 'actions', 'sessionId', 'count']);
+      expect(spy).toHaveBeenCalledWith(['select', 'sessionId', 'count', 'actions']);
     });
 
     it('should change columns order', () => {
@@ -178,11 +217,6 @@ describe('TableComponent', () => {
           sortable: false,
         },
         {
-          key: 'actions',
-          name: 'Actions',
-          sortable: false,
-        },
-        {
           key: 'sessionId',
           name: 'Session ID',
           sortable: true,
@@ -190,6 +224,11 @@ describe('TableComponent', () => {
         {
           key: 'count',
           name: 'count',
+          sortable: false,
+        },
+        {
+          key: 'actions',
+          name: 'Actions',
           sortable: false,
         },
       ]);

--- a/src/app/components/table/table.component.ts
+++ b/src/app/components/table/table.component.ts
@@ -1,17 +1,19 @@
 import { SelectionModel } from '@angular/cdk/collections';
 import { CdkDragDrop, DragDropModule, moveItemInArray } from '@angular/cdk/drag-drop';
-import { AfterViewInit, ChangeDetectionStrategy, Component, EventEmitter, Input, OnDestroy, Output, ViewChild } from '@angular/core';
+import { AfterViewInit, ChangeDetectionStrategy, Component, EventEmitter, inject, Input, OnDestroy, Output, ViewChild } from '@angular/core';
 import { MatPaginator, MatPaginatorModule } from '@angular/material/paginator';
 import { MatSort, MatSortModule } from '@angular/material/sort';
 import { MatTableModule } from '@angular/material/table';
 import { TasksStatusesGroup } from '@app/dashboard/types';
 import { TaskOptions } from '@app/tasks/types';
 import { GrpcAction } from '@app/types/actions.type';
-import { TableColumn } from '@app/types/column.type';
+import { ColumnsBehaviourValues, ColumnType, SpecialColumn, TableColumn } from '@app/types/column.type';
 import { ArmonikData, ColumnKey, DataRaw } from '@app/types/data';
 import { ListOptions } from '@app/types/options';
 import { Status, StatusService } from '@app/types/status';
 import { TableContainerComponent } from '@components/table-container.component';
+import { DefaultConfigService } from '@services/default-config.service';
+import { StorageService } from '@services/storage.service';
 import { TableActionsComponent } from './table-actions.component';
 import { TableCellComponent } from './table-cell.component';
 import { TableColumnHeaderComponent } from './table-column-header.component';
@@ -35,9 +37,13 @@ import { TableColumnHeaderComponent } from './table-column-header.component';
 export class TableComponent<T extends DataRaw, S extends Status, O extends TaskOptions | null = null> implements AfterViewInit, OnDestroy {
   // Required inputs
   @Input({ required: true }) set columns(entries: TableColumn<T, O>[]) {
-    const selectColumn = entries.find(column => column.key === 'select');
-    if (selectColumn) {
-      entries = [selectColumn, ...entries.filter(column => column.key !== 'select')];
+    for (const key of Object.keys(this.columnsBehaviour) as SpecialColumn[]) {
+      const column = entries.find(col => col.key === key);
+      if (column && this.columnsBehaviour[key] === ColumnsBehaviourValues.LEFT) {
+        entries = [column, ...entries.filter(col => col.key !== key)];
+      } else if (column && this.columnsBehaviour[key] === ColumnsBehaviourValues.RIGHT) {
+        entries = [...entries.filter(col => col.key !== key), column];
+      }
     }
     this._columns = entries;
     this._columnsKeys = entries.map((entry) => entry.key);
@@ -75,8 +81,15 @@ export class TableComponent<T extends DataRaw, S extends Status, O extends TaskO
   @Output() selectionChange = new EventEmitter<T[]>();
   @Output() personalizeTasksByStatus = new EventEmitter<void>();
 
+  private readonly storageService = inject(StorageService);
+  private readonly defaultConfigService = inject(DefaultConfigService);
+
   @ViewChild(MatPaginator) paginator: MatPaginator;
   @ViewChild(MatSort) sort: MatSort;
+
+  private readonly columnsBehaviour: Record<SpecialColumn, ColumnsBehaviourValues>;
+  readonly stickLeftColumns: ColumnType[];
+  readonly stickRightColumns: ColumnType[];
 
   private _data: ArmonikData<T, O>[];
   private _columns: TableColumn<T, O>[];
@@ -100,6 +113,13 @@ export class TableComponent<T extends DataRaw, S extends Status, O extends TaskO
   }
 
   selection = new SelectionModel<T>(true, []);
+
+  constructor() {
+    this.columnsBehaviour = this.storageService.getItem('table-columns-behaviour', true) as Record<SpecialColumn, ColumnsBehaviourValues> ?? this.defaultConfigService.defaultTableColumnsBehaviour;
+    const keys = Object.keys(this.columnsBehaviour) as SpecialColumn[];
+    this.stickLeftColumns = keys.filter(key => this.columnsBehaviour[key] === ColumnsBehaviourValues.LEFT);
+    this.stickRightColumns = keys.filter(key => this.columnsBehaviour[key] === ColumnsBehaviourValues.RIGHT);
+  }
 
   ngAfterViewInit(): void {
     this.sort.sortChange.subscribe(() => {

--- a/src/app/components/table/table.component.ts
+++ b/src/app/components/table/table.component.ts
@@ -37,16 +37,23 @@ import { TableColumnHeaderComponent } from './table-column-header.component';
 export class TableComponent<T extends DataRaw, S extends Status, O extends TaskOptions | null = null> implements AfterViewInit, OnDestroy {
   // Required inputs
   @Input({ required: true }) set columns(entries: TableColumn<T, O>[]) {
-    for (const key of Object.keys(this.columnsBehaviour) as SpecialColumn[]) {
-      const column = entries.find(col => col.key === key);
-      if (column && this.columnsBehaviour[key] === ColumnsBehaviourValues.LEFT) {
-        entries = [column, ...entries.filter(col => col.key !== key)];
-      } else if (column && this.columnsBehaviour[key] === ColumnsBehaviourValues.RIGHT) {
-        entries = [...entries.filter(col => col.key !== key), column];
+    const behavioursKeys = Object.keys(this.columnsBehaviour) as SpecialColumn[];
+    const leftMostColumns: TableColumn<T, O>[] = [];
+    const rightMostColumns: TableColumn<T, O>[] = [];
+    for (const column of entries) {
+      const behaviourKey = behavioursKeys.find(col => col === column.key);
+      if (behaviourKey && this.columnsBehaviour[behaviourKey] === ColumnsBehaviourValues.LEFT) {
+        leftMostColumns.push(column);
+      } else if (behaviourKey && this.columnsBehaviour[behaviourKey] === ColumnsBehaviourValues.RIGHT) {
+        rightMostColumns.push(column);
       }
     }
-    this._columns = entries;
-    this._columnsKeys = entries.map((entry) => entry.key);
+    this._columns = [
+      ...leftMostColumns ,
+      ...entries.filter(col => !leftMostColumns.includes(col) && !rightMostColumns.includes(col)),
+      ...rightMostColumns
+    ];
+    this._columnsKeys = this._columns.map((entry) => entry.key);
   }
 
   @Input({ required: true }) set data(entries: ArmonikData<T, O>[]) {

--- a/src/app/services/default-config.service.ts
+++ b/src/app/services/default-config.service.ts
@@ -6,6 +6,7 @@ import { PartitionRaw } from '@app/partitions/types';
 import { ResultRaw } from '@app/results/types';
 import { SessionRaw } from '@app/sessions/types';
 import { TaskOptions, TaskSummary } from '@app/tasks/types';
+import { ColumnsBehaviourValues } from '@app/types/column.type';
 import { ExportedDefaultConfig, ScopeConfig } from '@app/types/config';
 import { ExternalService } from '@app/types/external-service';
 import { LinkType } from '@app/types/graph.types';
@@ -244,6 +245,8 @@ export class DefaultConfigService {
     },
   };
 
+  readonly #defaultTableColumnsBehaviour: Record<string, ColumnsBehaviourValues> = {};
+
   readonly #defaultTasks: ScopeConfig<TaskSummary, TaskSummaryEnumField, TaskOptions, TaskOptionEnumField> = {
     interval: 10,
     lockColumns: false,
@@ -445,6 +448,10 @@ export class DefaultConfigService {
     return structuredClone(this.#defaultGraphHighlightChildren);
   }
 
+  get defaultTableColumnsBehaviour() {
+    return structuredClone(this.#defaultTableColumnsBehaviour);
+  }
+
   readonly #exportedDefaultConfig: ExportedDefaultConfig = {
     'language': this.#defaultLanguage,
     'navigation-sidebar': this.#defaultSidebar,
@@ -483,6 +490,7 @@ export class DefaultConfigService {
     'results-lock-columns': this.#defaultResults.lockColumns,
     'results-show-filters': this.#defaultResults.showFilters,
     'results-statuses': this.#defaultResultsStatuses,
+    'table-columns-behaviour': this.#defaultTableColumnsBehaviour,
     'tasks-columns': this.#defaultTasks.columns,
     'tasks-options': this.#defaultTasks.options,
     'tasks-filters': this.#defaultTasks.filters,

--- a/src/app/settings/component/columns-behaviour.component.html
+++ b/src/app/settings/component/columns-behaviour.component.html
@@ -1,0 +1,12 @@
+<app-page-section-header icon="grid_goldenratio">
+  <span i18n>Columns behaviour</span>
+</app-page-section-header>
+
+<section>
+  @for (column of columns.entries(); track $index) {
+    <div>
+      <p>{{ column[1].label }} <span i18n>columns:</span></p>
+      <app-autocomplete [options]="behaviours" [value]="column[1].value" i18n-label label="Behaviour" (valueChange)="updateBehaviour(column[0], $event)" />
+    </div>
+  }
+</section>

--- a/src/app/settings/component/columns-behaviour.component.scss
+++ b/src/app/settings/component/columns-behaviour.component.scss
@@ -1,0 +1,17 @@
+section {
+  margin-left: 2rem;
+  display: flex;
+  flex-direction: column;
+  width: fit-content;
+  gap: 1rem;
+
+  div {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+
+    span {
+      margin-right: 1rem;
+    }
+  }
+}

--- a/src/app/settings/component/columns-behaviour.component.spec.ts
+++ b/src/app/settings/component/columns-behaviour.component.spec.ts
@@ -1,0 +1,79 @@
+import { TestBed } from '@angular/core/testing';
+import { ColumnsBehaviourValues } from '@app/types/column.type';
+import { DefaultConfigService } from '@services/default-config.service';
+import { StorageService } from '@services/storage.service';
+import { ColumnsBehaviourComponent } from './columns-behaviour.component';
+
+describe('ColumnsBehaviourComponent', () => {
+  let component: ColumnsBehaviourComponent;
+
+  const mockStorageService = {
+    getItem: jest.fn(),
+    setItem: jest.fn(),
+  };
+
+  const mockDefaultConfigService = {
+    defaultTableColumnsBehaviour: {
+      'select': ColumnsBehaviourValues.LEFT,
+      'actions': undefined as unknown as ColumnsBehaviourValues // Check component line 39 condition
+    } as Record<string, ColumnsBehaviourValues>,
+  };
+
+  beforeEach(() => {
+    component = TestBed.configureTestingModule({
+      providers: [
+        ColumnsBehaviourComponent,
+        { provide: StorageService, useValue: mockStorageService },
+        { provide: DefaultConfigService, useValue: mockDefaultConfigService },
+      ],
+    }).inject(ColumnsBehaviourComponent);
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  describe('init', () => {
+    it('should look for the stored data', () => {
+      expect(mockStorageService.getItem).toHaveBeenCalledWith('table-columns-behaviour', true);
+    });
+
+    it('should set the default text value for each column', () => {
+      expect([...component.columns.values()].map(content => content.value)).toEqual(['Stick on the left', 'Unset']);
+    });
+  });
+
+  describe('getBehaviourFromText', () => {
+    it('should return UNSET is the text is "unset"', () => {
+      expect(component['getBehaviourFromText'](component.behaviours[0])).toEqual(ColumnsBehaviourValues.UNSET);
+    });
+    
+    it('should return LEFT is the text is "Stick on the left"', () => {
+      expect(component['getBehaviourFromText'](component.behaviours[1])).toEqual(ColumnsBehaviourValues.LEFT);
+    });
+    
+    it('should return RIGHT is the text is "Stick on the right"', () => {
+      expect(component['getBehaviourFromText'](component.behaviours[2])).toEqual(ColumnsBehaviourValues.RIGHT);
+    });
+  });
+
+  describe('updateBehaviour', () => {
+    beforeEach(() => {
+      component.updateBehaviour('select', component.behaviours[2]);
+    });
+
+    it('should update the correct text value', () => {
+      expect(component.columns.get('select')?.value).toBe(component.behaviours[2]);
+    });
+
+    it('should store the new value', () => {
+      expect(mockStorageService.setItem).toHaveBeenCalledWith(
+        'table-columns-behaviour',
+        { 
+          'actions': ColumnsBehaviourValues.UNSET,
+          'select': ColumnsBehaviourValues.RIGHT,
+        }
+      );
+    });
+  });
+});

--- a/src/app/settings/component/columns-behaviour.component.ts
+++ b/src/app/settings/component/columns-behaviour.component.ts
@@ -1,0 +1,73 @@
+import { Component, inject } from '@angular/core';
+import { ColumnsBehaviourValues, SpecialColumn } from '@app/types/column.type';
+import { AutoCompleteComponent } from '@components/auto-complete.component';
+import { PageSectionHeaderComponent } from '@components/page-section-header.component';
+import { DefaultConfigService } from '@services/default-config.service';
+import { StorageService } from '@services/storage.service';
+
+@Component({
+  selector: 'app-columns-behaviour',
+  templateUrl: 'columns-behaviour.component.html',
+  styleUrl: 'columns-behaviour.component.scss',
+  imports: [
+    AutoCompleteComponent,
+    PageSectionHeaderComponent
+  ]
+})
+export class ColumnsBehaviourComponent {
+  private readonly storageService = inject(StorageService);
+
+  readonly behaviours = [
+    $localize`Unset`,
+    $localize`Stick on the left`,
+    $localize`Stick on the right`,
+  ];
+
+  readonly columns: Map<
+    SpecialColumn,
+    { label: string, value: string }
+  > = new Map([
+      ['select', { label: $localize`Select`, value: '' }],
+      ['actions', { label: $localize`Actions`, value: '' }]
+    ]);
+
+  constructor(defaultConfigService: DefaultConfigService) {
+    const values = this.storageService.getItem('table-columns-behaviour', true) as Record<string, ColumnsBehaviourValues> ?? defaultConfigService.defaultTableColumnsBehaviour;
+    for (const column of this.columns.keys()) {
+      const content = this.columns.get(column);
+      if (content) {
+        content.value = this.getBehaviourText(values[column] ?? ColumnsBehaviourValues.UNSET);
+      }
+    }
+  }
+
+  private getBehaviourText(behaviour: ColumnsBehaviourValues) {
+    return this.behaviours[behaviour];
+  }
+
+  private getBehaviourFromText(text: string) {
+    if (text === this.behaviours[0]) {
+      return ColumnsBehaviourValues.UNSET;
+    } else if (text === this.behaviours[1]) {
+      return ColumnsBehaviourValues.LEFT;
+    } else {
+      return ColumnsBehaviourValues.RIGHT;
+    }
+  }
+
+  updateBehaviour(column: SpecialColumn, value: string) {
+    if (this.behaviours.includes(value)) {
+      const content = this.columns.get(column);
+      if (content) {
+        content.value = value;
+        this.storageService.setItem(
+          'table-columns-behaviour',
+          [...this.columns.entries()].reduce((acc, column) => {
+            acc[column[0]] = this.getBehaviourFromText(column[1].value);
+            return acc;
+          }, {} as Record<string, ColumnsBehaviourValues>)
+        );
+      }
+    }
+  }
+}

--- a/src/app/settings/index.component.html
+++ b/src/app/settings/index.component.html
@@ -30,6 +30,8 @@
     </div>
 
     <app-theme-selector />
+
+    <app-columns-behaviour />
   </article>
 
   <article>

--- a/src/app/settings/index.component.ts
+++ b/src/app/settings/index.component.ts
@@ -19,6 +19,7 @@ import { NotificationService } from '@services/notification.service';
 import { QueryParamsService } from '@services/query-params.service';
 import { StorageService } from '@services/storage.service';
 import { ClearAllDialogComponent } from './component/clear-all-dialog.component';
+import { ColumnsBehaviourComponent } from './component/columns-behaviour.component';
 import { ThemeSelectorComponent } from './component/theme-selector.component';
 
 @Component({
@@ -41,6 +42,7 @@ import { ThemeSelectorComponent } from './component/theme-selector.component';
     MatSnackBarModule,
     MatMenuModule,
     ThemeSelectorComponent,
+    ColumnsBehaviourComponent
   ],
 })
 export class IndexComponent implements OnInit {

--- a/src/app/types/column.type.ts
+++ b/src/app/types/column.type.ts
@@ -3,7 +3,8 @@ import { ColumnKey, DataRaw } from '@app/types/data';
 import { Scope } from './config';
 
 export type DataType = 'raw' | 'link' | 'object' | 'date' | 'duration' | 'status' | 'array' | 'output' | 'message' | 'byte-array'; 
-export type ColumnType = DataType | 'count' | 'actions' | 'select';
+export type SpecialColumn = 'actions' | 'select';
+export type ColumnType = DataType | SpecialColumn | 'count';
 
 export type Field<T extends DataRaw | TaskOptions | null> = {
   key: keyof T;
@@ -18,4 +19,10 @@ export type TableColumn<T extends DataRaw, O extends TaskOptions | null = null> 
   type?: ColumnType;
   sortable: boolean;
   link?: string;
+};
+
+export enum ColumnsBehaviourValues {
+  UNSET = 0,
+  LEFT = 1,
+  RIGHT = 2,
 };

--- a/src/app/types/config.ts
+++ b/src/app/types/config.ts
@@ -24,6 +24,7 @@ export type Key =
   'navigation-theme' |
   'navigation-color-scheme' |
   'navigation-external-services' |
+  'table-columns-behaviour' |
   'dashboard-lines'|
   'dashboard-split-lines' |
   'applications-tasks-by-status' |


### PR DESCRIPTION
GUI v0.15.0 introduced a behaviour for actions and select columns. Actions columns where always on the right of the table, and select columns where always on the left. For some clients, it was not the most welcomed change, and we had to rollback this change in 0.15.1.

The goal in this pull request is to add again the behaviour of the "select" and "actions columns". This time, the choice is being left to the user on how they want those columns to behave:
<img width="340" height="272" alt="image" src="https://github.com/user-attachments/assets/3ae80290-1b2e-40f8-afcd-33a777112814" />

Both columns can now be set to either left, right, or not being moved at all. Default value is unset for both.