### PR TITLE
fix: tables should always go to the last page when out of bounds

### DIFF
--- a/src/app/applications/services/applications-data.service.spec.ts
+++ b/src/app/applications/services/applications-data.service.spec.ts
@@ -205,7 +205,7 @@ describe('ApplicationDataService', () => {
         expect(mockApplicationsGrpcService.list$).toHaveBeenCalledWith(
           {
             ...service.options,
-            pageIndex: Math.floor(total / service.options.pageSize),
+            pageIndex: 9, // last page for 100 items with a pageSize of 10
           },
           service.filters
         );

--- a/src/app/partitions/services/partitions-data.service.spec.ts
+++ b/src/app/partitions/services/partitions-data.service.spec.ts
@@ -200,7 +200,7 @@ describe('PartitionsDataService', () => {
         expect(mockPartitionsGrpcService.list$).toHaveBeenCalledWith(
           {
             ...service.options,
-            pageIndex: Math.floor(total / service.options.pageSize),
+            pageIndex: 9, // last page for 100 items with a pageSize of 10
           },
           service.filters
         );

--- a/src/app/results/services/results-data.service.spec.ts
+++ b/src/app/results/services/results-data.service.spec.ts
@@ -161,7 +161,7 @@ describe('ResultsDataService', () => {
         expect(mockResultsGrpcService.list$).toHaveBeenCalledWith(
           {
             ...service.options,
-            pageIndex: Math.floor(total / service.options.pageSize),
+            pageIndex: 9, // last page for 100 items with a pageSize of 10
           },
           service.filters
         );

--- a/src/app/sessions/services/sessions-data.service.spec.ts
+++ b/src/app/sessions/services/sessions-data.service.spec.ts
@@ -301,7 +301,7 @@ describe('SessionsDataService', () => {
         expect(mockSessionsGrpcService.list$).toHaveBeenCalledWith(
           {
             ...service.options,
-            pageIndex: Math.floor(total / service.options.pageSize),
+            pageIndex: 9, // last page for 100 items with a pageSize of 10
           },
           service.filters
         );

--- a/src/app/tasks/services/tasks-data.service.spec.ts
+++ b/src/app/tasks/services/tasks-data.service.spec.ts
@@ -176,10 +176,46 @@ describe('TasksDataService', () => {
         expect(mockTasksGrpcService.list$).toHaveBeenCalledWith(
           {
             ...service.options,
-            pageIndex: Math.floor(total / service.options.pageSize),
+            pageIndex: 9, // last page for 100 items with a pageSize of 10
           },
           service.filters
         );
+      });
+    });
+
+    describe('Gets no data while the database is empty', () => {
+      beforeEach(() => {
+        mockTasksGrpcService.list$.mockReturnValueOnce(of({
+          tasks: [],
+          total: 0,
+          pageSize: service.options.pageSize,
+        } as unknown as ListTasksResponse));
+        service.refresh$.next();
+      });
+
+      it('should render an empty table without clamping or refetching', () => {
+        expect(mockTasksGrpcService.list$).toHaveBeenCalledTimes(1);
+        expect(service.data()).toEqual([]);
+      });
+    });
+
+    describe('Gets no data while already on the last page', () => {
+      const total = 100;
+
+      beforeEach(() => {
+        // stale total: the database reports data but the last page itself comes back empty
+        service.options.pageIndex = 9; // last page for 100 items with a pageSize of 10
+        mockTasksGrpcService.list$.mockReturnValueOnce(of({
+          tasks: [],
+          total: total,
+          pageSize: service.options.pageSize,
+        } as unknown as ListTasksResponse));
+        service.refresh$.next();
+      });
+
+      it('should not loop and should render an empty table', () => {
+        expect(mockTasksGrpcService.list$).toHaveBeenCalledTimes(1);
+        expect(service.data()).toEqual([]);
       });
     });
   });

--- a/src/app/types/services/table-data.service.ts
+++ b/src/app/types/services/table-data.service.ts
@@ -82,7 +82,7 @@ export abstract class AbstractTableDataService<T extends DataRaw, F extends Filt
       })
     ).subscribe((entries) => {
       const total = this.total();
-      if (entries.length === 0 && total !== 0) {
+      if (this.shouldClampToLastPage(entries.length, total)) {
         this.setToLastPage(total);
       } else {
         this.handleData(entries);
@@ -114,13 +114,42 @@ export abstract class AbstractTableDataService<T extends DataRaw, F extends Filt
   }
 
   /**
+   * Compute the index of the last page that actually contains data.
+   * Pages are zero-indexed, so for a total that is an exact multiple of the page size
+   * the last page index is `total / pageSize - 1` (hence `ceil(total / pageSize) - 1`).
+   * @param total the total number of data stored in the database
+   */
+  private computeLastPageIndex(total: number): number {
+    if (total === 0 || this.options.pageSize <= 0) {
+      return 0;
+    }
+    return Math.ceil(total / this.options.pageSize) - 1;
+  }
+
+  /**
+   * Whether the current page must be clamped to the last page that holds data.
+   *
+   * Returns `true` only when the latest fetch came back empty while the database still
+   * holds data (`total !== 0`) and the current page is not already the last one.
+   * - The `total !== 0` check lets a genuinely empty result render as an empty table
+   *   instead of triggering a clamp.
+   * - The page-index check prevents an infinite refresh loop when the last page itself
+   *   returns no data (e.g. a stale `total` after a deletion).
+   * @param entriesCount number of entries returned by the latest fetch
+   * @param total the total number of data stored in the database
+   */
+  private shouldClampToLastPage(entriesCount: number, total: number): boolean {
+    return entriesCount === 0 && total !== 0 && this.options.pageIndex !== this.computeLastPageIndex(total);
+  }
+
+  /**
    * Called when no data are received while there is still some in the database.
    * This case generally happens when data is filtered or deleted while the user is on one of the latest page of the table.
-   * Refreshes automatically the data.
+   * Clamps the current page to the last page that holds data and refreshes automatically.
    * @param total the total number of data stored in the database
    */
   private setToLastPage(total: number) {
-    this.options.pageIndex = Math.floor(total / this.options.pageSize);
+    this.options.pageIndex = this.computeLastPageIndex(total);
     this.refresh$.next();
   }
 


### PR DESCRIPTION
# Motivation

#1367 introduced the "jump to the last page when the current page is out of bounds" behavior, but its page-index math had an off-by-one. The last page was computed as `Math.floor(total / pageSize)`, which returns the index *one past* the last page whenever `total` is an exact multiple of `pageSize` (e.g. `total = 100`, `pageSize = 10` → index `10`, but the last valid index is `9`). That landed the user on another out-of-bounds page.

# Description
Fix the clamping math so a table that is out of bounds reliably lands on the last page that actually holds data.
<img width="1280" height="720" alt="deletion-clamp-behavior" src="https://github.com/user-attachments/assets/96190a92-3216-4b4a-b46e-557a888b3ae4" />


# Testing

- Updated the five `*-data.service.spec.ts` suites (applications, partitions, results, sessions, tasks) to assert the corrected last-page index (`Math.ceil(total / pageSize) - 1`).
- Manually verified against a live ArmoniK deployment

# Impact

Not Applicable.

# Additional Information

Not Applicable. 

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.