### PR TITLE
fix: added semver parsing to API version

### DIFF
--- a/src/app/services/versions.service.spec.ts
+++ b/src/app/services/versions.service.spec.ts
@@ -15,9 +15,9 @@ describe('versions service', () => {
       expect(service.core()).toBe(coreVersion);
     });
 
-    it('should send an error message when core version does not contain only numbers', () => {
+    it('should keep the raw string when core version does not contain only numbers', () => {
       service.setCoreVersion('nouvelle.8.de.3');
-      expect(service.core()).toBeUndefined();
+      expect(service.core()).toBe('nouvelle.8.de.3');
     });
 
     it('should send an error message when core version is equal to null', () => {
@@ -33,9 +33,9 @@ describe('versions service', () => {
       expect(service.api()).toEqual(apiVersion);
     });
 
-    it('should only be numbers', () => {
+    it('should keep the raw string when API version does not contain only numbers', () => {
       service.setAPIVersion('nouvelle.5.de.aping');
-      expect(service.api()).toBeUndefined();
+      expect(service.api()).toBe('nouvelle.5.de.aping');
     });
     it('should send an error message when API version is equal to null', () => {
       service.setAPIVersion();

--- a/src/app/services/versions.service.ts
+++ b/src/app/services/versions.service.ts
@@ -11,7 +11,7 @@ export class VersionsService {
    */
   private formatVersion(version: string | null): string | undefined {
     if (version !== null) {
-      const versionNumber = version.split('.').map(Number);
+      const versionNumber = version.split(/[+-]/)[0].split('.').map(Number);
       const isInvalidNumber = versionNumber.some(number => Number.isNaN(number));
       if (!isInvalidNumber) {
         return this.fixVersion(versionNumber);

--- a/src/app/services/versions.service.ts
+++ b/src/app/services/versions.service.ts
@@ -6,8 +6,9 @@ export class VersionsService {
   readonly api = signal<string | undefined>(undefined);
 
   /**
-   * Check if the version is only composed from numbers.
-   * If it is, returns it. If not, returns the VERSION_NOT_FOUND.
+   * Format the version as "major.minor.patch", ignoring any pre-release or build suffix.
+   * Falls back to the raw string when it cannot be parsed as numbers,
+   * and to undefined when there is no version at all.
    */
   private formatVersion(version: string | null): string | undefined {
     if (version !== null) {
@@ -16,6 +17,7 @@ export class VersionsService {
       if (!isInvalidNumber) {
         return this.fixVersion(versionNumber);
       }
+      return version;
     }
     return undefined;
   }


### PR DESCRIPTION
# Motivation

Failed to parse API version in the dropdown, marking the version as "unavailable" 

# Description

Added a split on the semver, so we can extract the proper part of the version string.
<img width="395" height="263" alt="image" src="https://github.com/user-attachments/assets/3e7041a9-b233-42a3-88ad-6da48a893c98" />



# Testing

Not Applicable.

# Impact

Not Applicable.

# Additional Information

Not Applicable. 

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.