### PR TITLE
docs: redirect GitHub Pages to Read the Docs

### DIFF
--- a/.github/pages-redirect/index.html
+++ b/.github/pages-redirect/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>ArmoniK.Admin.GUI documentation has moved</title>
+  <meta http-equiv="refresh" content="0; url=https://armonikadmingui.readthedocs.io/en/latest/" />
+  <link rel="canonical" href="https://armonikadmingui.readthedocs.io/en/latest/" />
+  <script>
+    window.location.replace("https://armonikadmingui.readthedocs.io/en/latest/");
+  </script>
+</head>
+<body>
+  <p>
+    This documentation has moved to
+    <a href="https://armonikadmingui.readthedocs.io/en/latest/">Read the Docs</a>.
+  </p>
+</body>
+</html>

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -1,0 +1,44 @@
+name: Deploy Docs to Pages
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/pages-redirect/**"
+      - ".github/workflows/doc.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build-docs:
+    name: Build Docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
+        with:
+          path: .github/pages-redirect
+
+  deploy:
+    needs: build-docs
+    name: Deploy to GitHub Pages
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@decdde0ac072f6dcbe43649d82d9c635fff5b4e4 # v4


### PR DESCRIPTION
The old Pages deployment workflow was removed when docs migrated to Sphinx/Read the Docs, but the site is still live with stale content. Replace it with a minimal redirect page in order to not to break the previous link which may be still used in older presentations or documentation.